### PR TITLE
Make Trace object-safe, allowing dynamic types and slices to be garbage collected

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -15,7 +15,7 @@
 //! and it'll generate a safe wrapper.
 use core::cell::Cell;
 
-use crate::{GcSafe, Trace, GcVisitor, NullTrace, TraceImmutable, GcDirectBarrier, GcTypeInfo, GcDynVisitError, GcDynVisitor};
+use crate::prelude::*;
 
 /// A `Cell` pointing to a garbage collected object.
 ///
@@ -67,8 +67,8 @@ impl<T: NullTrace + Copy> GcCell<T> {
 /// Trigger a write barrier on the inner value
 ///
 /// We are a 'direct' write barrier because `Value` is stored inline
-unsafe impl<'gc, OwningRef, Value> GcDirectBarrier<'gc, OwningRef> for GcCell<Value>
-    where Value: GcDirectBarrier<'gc, OwningRef> + Copy {
+unsafe impl<'gc, OwningRef, Value> crate::GcDirectBarrier<'gc, OwningRef> for GcCell<Value>
+    where Value: crate::GcDirectBarrier<'gc, OwningRef> + Copy {
     #[inline]
     unsafe fn write_barrier(
         &self, owner: &OwningRef,
@@ -109,7 +109,7 @@ unsafe impl<T: GcSafe + NullTrace + Copy> TraceImmutable for GcCell<T> {
 }
 unsafe impl<T: GcSafe + Copy + NullTrace> NullTrace for GcCell<T> {}
 unsafe impl<T: GcSafe + Copy> GcSafe for GcCell<T> {}
-unsafe impl<T: Trace + Copy> GcTypeInfo for GcCell<T> {
+unsafe impl<T: GcType + Copy> GcType for GcCell<T> {
     const NEEDS_TRACE: bool = T::NEEDS_TRACE;
     /// Since T is Copy, we shouldn't need to be dropped
     const NEEDS_DROP: bool = false;

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -89,11 +89,6 @@ unsafe impl<T: Trace + Copy> Trace for GcCell<T> {
     fn visit<V: GcVisitor>(&mut self, visitor: &mut V) -> Result<(), V::Err> {
         visitor.visit(self.get_mut())
     }
-
-    #[inline]
-    fn visit_dyn(&mut self, visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
-        self.visit(visitor)
-    }
 }
 /// See Trace documentation on the safety of mutation
 ///

--- a/src/dummy_impl.rs
+++ b/src/dummy_impl.rs
@@ -1,6 +1,6 @@
 //! Dummy collector implementation for testing
 
-use crate::{Trace, TraceImmutable, GcVisitor, NullTrace, CollectorId, GcSafe, GcSystem, GcContext, GcTypeInfo, GcDynVisitError, GcDynVisitor};
+use crate::{Trace, TraceImmutable, GcVisitor, NullTrace, CollectorId, GcSafe, GcSystem, GcContext, GcType, GcDynVisitError, GcDynVisitor};
 use std::ptr::NonNull;
 
 /// Fake a [Gc] that points to the specified value
@@ -114,7 +114,7 @@ unsafe impl TraceImmutable for DummyCollectorId {
         Ok(())
     }
 }
-unsafe impl GcTypeInfo for DummyCollectorId {
+unsafe impl GcType for DummyCollectorId {
     const NEEDS_TRACE: bool = false;
     const NEEDS_DROP: bool = false;
 }

--- a/src/dummy_impl.rs
+++ b/src/dummy_impl.rs
@@ -1,9 +1,6 @@
 //! Dummy collector implementation for testing
 
-use crate::{
-    Trace, TraceImmutable, GcVisitor, NullTrace, CollectorId,
-    GcSafe, GcSystem, GcContext,
-};
+use crate::{Trace, TraceImmutable, GcVisitor, NullTrace, CollectorId, GcSafe, GcSystem, GcContext, GcTypeInfo, GcDynVisitError, GcDynVisitor};
 use std::ptr::NonNull;
 
 /// Fake a [Gc] that points to the specified value
@@ -103,9 +100,11 @@ pub struct DummyCollectorId {
     _priv: ()
 }
 unsafe impl Trace for DummyCollectorId {
-    const NEEDS_TRACE: bool = false;
-
     fn visit<V: GcVisitor>(&mut self, _visitor: &mut V) -> Result<(), <V as GcVisitor>::Err> {
+        Ok(())
+    }
+    #[inline]
+    fn visit_dyn(&mut self, _visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
         Ok(())
     }
 }
@@ -113,6 +112,15 @@ unsafe impl TraceImmutable for DummyCollectorId {
     fn visit_immutable<V: GcVisitor>(&self, _visitor: &mut V) -> Result<(), V::Err> {
         Ok(())
     }
+
+    #[inline]
+    fn visit_dyn_immutable(&self, _visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
+        Ok(())
+    }
+}
+unsafe impl GcTypeInfo for DummyCollectorId {
+    const NEEDS_TRACE: bool = false;
+    const NEEDS_DROP: bool = false;
 }
 
 unsafe impl NullTrace for DummyCollectorId {}

--- a/src/dummy_impl.rs
+++ b/src/dummy_impl.rs
@@ -103,10 +103,6 @@ unsafe impl Trace for DummyCollectorId {
     fn visit<V: GcVisitor>(&mut self, _visitor: &mut V) -> Result<(), <V as GcVisitor>::Err> {
         Ok(())
     }
-    #[inline]
-    fn visit_dyn(&mut self, _visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
-        Ok(())
-    }
 }
 unsafe impl TraceImmutable for DummyCollectorId {
     fn visit_immutable<V: GcVisitor>(&self, _visitor: &mut V) -> Result<(), V::Err> {

--- a/src/manually_traced/indexmap.rs
+++ b/src/manually_traced/indexmap.rs
@@ -47,7 +47,7 @@ unsafe impl<'new_gc, Id, K, V> GcRebrand<'new_gc, Id> for IndexMap<K, V>
     >;
 }
 
-unsafe impl<K, V> GcTypeInfo for IndexMap<K, V>
+unsafe impl<K, V> GcType for IndexMap<K, V>
     where K: TraceImmutable + Eq + Hash, V: Trace {
     /// IndexMap has internal memory
     const NEEDS_TRACE: bool = K::NEEDS_TRACE | V::NEEDS_TRACE;
@@ -100,7 +100,7 @@ unsafe impl<'a, Id, V> GcErase<'a, Id> for IndexSet<V>
           <V as GcErase<'a, Id>>::Erased: TraceImmutable + Eq + Hash, {
     type Erased = IndexSet<<V as GcErase<'a, Id>>::Erased>;
 }
-unsafe impl<V> GcTypeInfo for IndexSet<V>
+unsafe impl<V> GcType for IndexSet<V>
     where V: TraceImmutable + Eq + Hash {
     const NEEDS_TRACE: bool = V::NEEDS_TRACE;
     /// IndexSet has internal memory

--- a/src/manually_traced/mod.rs
+++ b/src/manually_traced/mod.rs
@@ -177,7 +177,7 @@ macro_rules! unsafe_trace_deref {
                 visitor.visit_immutable(extracted)
             }
         }
-        unsafe impl<$($param),*> GcTypeInfo for $target<$($param),*>
+        unsafe impl<$($param),*> GcType for $target<$($param),*>
             where $($param: TraceImmutable),* {
             const NEEDS_TRACE: bool = $($param::NEEDS_TRACE || )* false;
             /*
@@ -230,7 +230,7 @@ macro_rules! unsafe_trace_deref {
         /// We trust ourselves to not do anything bad as long as our paramaters don't
         unsafe impl<$($param),*> GcSafe for $target<$($param),*>
             where $($param: GcSafe),*  {}
-        unsafe impl<$($param),*> GcTypeInfo for $target<$($param),*>
+        unsafe impl<$($param),*> GcType for $target<$($param),*>
             where $($param: Trace),* {
             const NEEDS_TRACE: bool = $($param::NEEDS_TRACE || )* false;
             /*
@@ -357,7 +357,7 @@ macro_rules! unsafe_trace_primitive {
         unsafe impl $crate::NullTrace for $target {}
         /// No drop/custom behavior -> GcSafe
         unsafe impl GcSafe for $target {}
-        unsafe impl GcTypeInfo for $target {
+        unsafe impl GcType for $target {
             const NEEDS_TRACE: bool = false;
             const NEEDS_DROP: bool = core::mem::needs_drop::<$target>();
         }

--- a/src/manually_traced/mod.rs
+++ b/src/manually_traced/mod.rs
@@ -176,10 +176,6 @@ macro_rules! unsafe_trace_deref {
                 };
                 visitor.visit_immutable(extracted)
             }
-            #[inline]
-            fn visit_dyn(&mut self, visitor: &mut GcDynVisitor) -> Result<(), $crate::GcDynVisitError> {
-                self.visit::<GcDynVisitor>(visitor)
-            }
         }
         unsafe impl<$($param),*> GcTypeInfo for $target<$($param),*>
             where $($param: TraceImmutable),* {
@@ -229,10 +225,6 @@ macro_rules! unsafe_trace_deref {
                 };
                 visitor.visit(extracted)
             }
-            #[inline]
-            fn visit_dyn(&mut self, visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
-                self.visit(visitor)
-            }
         }
         unsafe impl<$($param: NullTrace),*> NullTrace for $target<$($param),*> {}
         /// We trust ourselves to not do anything bad as long as our paramaters don't
@@ -240,7 +232,7 @@ macro_rules! unsafe_trace_deref {
             where $($param: GcSafe),*  {}
         unsafe impl<$($param),*> GcTypeInfo for $target<$($param),*>
             where $($param: Trace),* {
-            const NEEDS_TRACE: bool = $($crate::needs_trace::<$param>() || )* false;
+            const NEEDS_TRACE: bool = $($param::NEEDS_TRACE || )* false;
             /*
              * NOTE: Because we are a wrapper class, we may have a custom drop.
              * Therefore we (more conservatively) base our drop decisions
@@ -349,10 +341,6 @@ macro_rules! unsafe_trace_primitive {
         unsafe impl Trace for $target {
             #[inline(always)] // This method does nothing and is always a win to inline
             fn visit<V: $crate::GcVisitor>(&mut self, _visitor: &mut V) -> Result<(), V::Err> {
-                Ok(())
-            }
-            #[inline]
-            fn visit_dyn(&mut self, _visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
                 Ok(())
             }
         }

--- a/src/manually_traced/stdlib.rs
+++ b/src/manually_traced/stdlib.rs
@@ -11,21 +11,17 @@ use crate::CollectorId;
 unsafe_immutable_trace_iterable!(HashMap<K, V>; element = { (&K, &V) });
 unsafe impl<K: TraceImmutable, V: Trace> Trace for HashMap<K, V> {
     fn visit<Visit: GcVisitor>(&mut self, visitor: &mut Visit) -> Result<(), Visit::Err> {
-        if !crate::needs_trace::<Self>() { return Ok(()); };
+        if !Self::NEEDS_TRACE { return Ok(()); };
         for (key, value) in self.iter_mut() {
             visitor.visit_immutable(key)?;
             visitor.visit(value)?;
         }
         Ok(())
     }
-    #[inline]
-    fn visit_dyn(&mut self, visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
-        self.visit::<GcDynVisitor>(visitor)
-    }
 }
 unsafe impl<K: GcSafe + TraceImmutable, V: GcSafe> GcSafe for HashMap<K, V> {}
 unsafe impl<K: TraceImmutable, V: Trace> GcTypeInfo for HashMap<K, V> {
-    const NEEDS_TRACE: bool = crate::needs_trace::<K>() || crate::needs_trace::<V>();
+    const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
     const NEEDS_DROP: bool = true; // HashMap has native-allocated internal memory
 }
 unsafe impl<'new_gc, Id, K, V> GcRebrand<'new_gc, Id> for HashMap<K, V>
@@ -51,19 +47,15 @@ unsafe impl<'a, Id, K, V> GcErase<'a, Id> for HashMap<K, V>
 unsafe_immutable_trace_iterable!(HashSet<V>; element = { &V });
 unsafe impl<V: TraceImmutable> Trace for HashSet<V> {
     fn visit<Visit: GcVisitor>(&mut self, visitor: &mut Visit) -> Result<(), Visit::Err> {
-        if !crate::needs_trace::<Self>() { return Ok(()); };
+        if !Self::NEEDS_TRACE { return Ok(()); };
         for value in self.iter() {
             visitor.visit_immutable(value)?;
         }
         Ok(())
     }
-    #[inline]
-    fn visit_dyn(&mut self, visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
-        self.visit::<GcDynVisitor>(visitor)
-    }
 }
 unsafe_gc_brand!(HashSet, immut = required; V);
 unsafe impl<V: TraceImmutable> GcTypeInfo for HashSet<V> {
-    const NEEDS_TRACE: bool = crate::needs_trace::<V>();
+    const NEEDS_TRACE: bool = V::NEEDS_TRACE;
     const NEEDS_DROP: bool = true; // We have internal memory
 }

--- a/src/manually_traced/stdlib.rs
+++ b/src/manually_traced/stdlib.rs
@@ -10,19 +10,23 @@ use crate::CollectorId;
 
 unsafe_immutable_trace_iterable!(HashMap<K, V>; element = { (&K, &V) });
 unsafe impl<K: TraceImmutable, V: Trace> Trace for HashMap<K, V> {
-    const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
-
     fn visit<Visit: GcVisitor>(&mut self, visitor: &mut Visit) -> Result<(), Visit::Err> {
-        if !Self::NEEDS_TRACE { return Ok(()); };
+        if !crate::needs_trace::<Self>() { return Ok(()); };
         for (key, value) in self.iter_mut() {
             visitor.visit_immutable(key)?;
             visitor.visit(value)?;
         }
         Ok(())
     }
+    #[inline]
+    fn visit_dyn(&mut self, visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
+        self.visit::<GcDynVisitor>(visitor)
+    }
 }
-unsafe impl<K: GcSafe + TraceImmutable, V: GcSafe> GcSafe for HashMap<K, V> {
-    const NEEDS_DROP: bool = true; // HashMap has internal memory
+unsafe impl<K: GcSafe + TraceImmutable, V: GcSafe> GcSafe for HashMap<K, V> {}
+unsafe impl<K: TraceImmutable, V: Trace> GcTypeInfo for HashMap<K, V> {
+    const NEEDS_TRACE: bool = crate::needs_trace::<K>() || crate::needs_trace::<V>();
+    const NEEDS_DROP: bool = true; // HashMap has native-allocated internal memory
 }
 unsafe impl<'new_gc, Id, K, V> GcRebrand<'new_gc, Id> for HashMap<K, V>
     where Id: CollectorId, K: TraceImmutable + GcRebrand<'new_gc, Id>,
@@ -46,14 +50,20 @@ unsafe impl<'a, Id, K, V> GcErase<'a, Id> for HashMap<K, V>
 }
 unsafe_immutable_trace_iterable!(HashSet<V>; element = { &V });
 unsafe impl<V: TraceImmutable> Trace for HashSet<V> {
-    const NEEDS_TRACE: bool = V::NEEDS_TRACE;
-
     fn visit<Visit: GcVisitor>(&mut self, visitor: &mut Visit) -> Result<(), Visit::Err> {
-        if !Self::NEEDS_TRACE { return Ok(()); };
+        if !crate::needs_trace::<Self>() { return Ok(()); };
         for value in self.iter() {
             visitor.visit_immutable(value)?;
         }
         Ok(())
     }
+    #[inline]
+    fn visit_dyn(&mut self, visitor: &mut GcDynVisitor) -> Result<(), GcDynVisitError> {
+        self.visit::<GcDynVisitor>(visitor)
+    }
 }
 unsafe_gc_brand!(HashSet, immut = required; V);
+unsafe impl<V: TraceImmutable> GcTypeInfo for HashSet<V> {
+    const NEEDS_TRACE: bool = crate::needs_trace::<V>();
+    const NEEDS_DROP: bool = true; // We have internal memory
+}

--- a/src/manually_traced/stdlib.rs
+++ b/src/manually_traced/stdlib.rs
@@ -20,7 +20,7 @@ unsafe impl<K: TraceImmutable, V: Trace> Trace for HashMap<K, V> {
     }
 }
 unsafe impl<K: GcSafe + TraceImmutable, V: GcSafe> GcSafe for HashMap<K, V> {}
-unsafe impl<K: TraceImmutable, V: Trace> GcTypeInfo for HashMap<K, V> {
+unsafe impl<K: TraceImmutable, V: Trace> GcType for HashMap<K, V> {
     const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
     const NEEDS_DROP: bool = true; // HashMap has native-allocated internal memory
 }
@@ -55,7 +55,7 @@ unsafe impl<V: TraceImmutable> Trace for HashSet<V> {
     }
 }
 unsafe_gc_brand!(HashSet, immut = required; V);
-unsafe impl<V: TraceImmutable> GcTypeInfo for HashSet<V> {
+unsafe impl<V: TraceImmutable> GcType for HashSet<V> {
     const NEEDS_TRACE: bool = V::NEEDS_TRACE;
     const NEEDS_DROP: bool = true; // We have internal memory
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,7 +20,7 @@ pub use crate::{
 // Traits for user code to implement
 pub use crate::{
     GcSafe, GcErase, GcRebrand, Trace, TraceImmutable,
-    NullTrace, GcTypeInfo
+    NullTrace, GcType
 };
 // Hack traits
 pub use crate::{GcBindHandle};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,11 +15,12 @@ pub use crate::{
 // Basic collector types
 pub use crate::{
     GcSystem, GcContext, GcSimpleAlloc,
-    Gc, GcHandle, GcVisitor
+    Gc, GcHandle, GcVisitor, GcDynVisitor, GcDynVisitError
 };
 // Traits for user code to implement
 pub use crate::{
-    GcSafe, GcErase, GcRebrand, Trace, TraceImmutable, NullTrace
+    GcSafe, GcErase, GcRebrand, Trace, TraceImmutable,
+    NullTrace, GcTypeInfo
 };
 // Hack traits
 pub use crate::{GcBindHandle};


### PR DESCRIPTION
The simple part is making a dynamically dispatched version of 'Trace' and 'GcVisitor'. I just added `where Self: Sized` bounds to all the generic methods and added an object-safe fallback.

This main problem is that 'Trace' and 'GcSafe' have associated
constants 'Trace::NEEDS_TRACE' and 'GcSafe::NEEDS_DROP'.

I've separated these associated consts into their own GcTypeInfno
trait.

I've messed around with this all day.
So far it looks like we might end up requiring significant amounts of
nightly features D:

Fixes #15 
Required for #16

## Goals
1. Include 'NEEDS_TRACE' optimization to avoid un-needed tracing
    - Possibly just use `NullTrace` maker as a simpler alternative
2. Avoid invoking auto-derived dummy drops
    - These are generated by the derive code, forbidding the user from implementing a custom drop that resurrects objects
    - In that case `std::mem::needs_drop` may return a false-positive `true`
3. Avoid adding new nightly features
    - If we do need to add any they must have an accepted RFC
    - Ideally, we don't want to add very complex features (IE: not specialization)
4. Preserve static type information and avoid dynamic dispatch wherever possible
    - Can we include some sort of `StaticTypeLayout` struct in the future
    - This depends on static type information being perserve

## Approaches
I see three main approaches that keep the current type hierarchy, and there are pitfalls to each one.

Right now I'm leaning towards separate `DynTrace` types or having separate trait requirements for sized and unsized types.

### Require `where *const Self: GcTypeInfo` for all Trace types
Directly extending `Trace` from `GcTypeInfo` doesn't work. The rust compiler requires supertypes to be object-safe.
When wrapped with a pointer, the type can then implement non-object-safe constants. We simply add functions `needs_trace` and `needs_gc_drop` which query `<*const T as GcTypeInfo>::NEEDS_TRACE` (or `NEEDS_DROP`).

The big advantage is this approach works on stable!
The disadvantage is that the bound isn't implied for generic parameters.
If you have `impl<T: Trace> Trace for Box<T>` then the compiler complains that `*const T` doesn't implement `GcTypeInfo`.
You must explicitly add a where-bound `where *const T: GcTypeInfo` to each and every generic parameter :roll_eyes: 

The implied generic parameters would be fixed by [RFC 2089](https://github.com/rust-lang/rfcs/blob/master/text/2089-implied-bounds.md). However, this would probably require nightly, maybe even for API clients.

### Specialization
We could use specialization internally to implement `needs_trace` and `needs_drop` functions.
````
trait HiddenTypeInfo {
    const NEEDS_TRACE: bool;
    const NEEDS_DROP: bool;
}
default impl<T: ?Sized> HiddenTypeInfo for T {
    const NEEDS_TRACE: bool = true; // conservatively assume trace
    const NEEDS_DROP: bool = true; // conservative assume drop
}
impl<T: NullTrace> for T {
    const NEEDS_TRACE: bool = false;
}
impl<T: DummyDrop> for T {
    const NEEDS_DROP: bool = false;
}
````

### Problems
- Unfortunately, this doesn't work with [`min_specialization`](https://github.com/rust-lang/rust/pull/68970)
   - The full `specialization` feature is unsound, so we absolutely want to avoid it
   - It breaks [requirement 3](https://github.com/rust-lang/rust/blob/c4df63f47f37cfb8fff80919be560e4d51ae9a44/compiler/rustc_typeck/src/impl_wf_check/min_specialization.rs#L20)
      - I think this has something to do with [always applicable impls](https://smallcultfollowing.com/babysteps/blog/2018/02/09/maximally-minimal-specialization-always-applicable-impls/)
      - This could be fixed (in theory) if we used the compiler-internal attribute `#[rustc_unsafe_specialization_marker]`
   - Maybe we should just ignore it since we know that our specific use-case is fine?
- How would we require `GcTypeInfo` to be implemented for all `Trace + Sized` types?

## Associated Type
We could require an associated type `type Info: GcTypeInfo`. By default, the associated type would be `Self` for any `Sized` types. However, for unsized types we would have `Info = DefaultTypeInfo` that gives conservative defaults.

Associated type defaults were accepted in [RFC 2532](https://github.com/rust-lang/rfcs/blob/master/text/2532-associated-type-defaults.md). 

### Problems
- The feature is unstable (though not as bad as specialization).
- This is only theoretical. I haven't tried it yet
- Does this work if we don't have a `Self: GcTypeInfo` bound on the trait?
- Kind of an ugly approach

## Separate erased traits: `DynTrace` and `DynGcVisitor`
This is what [erased serde](https://docs.rs/erased-serde) did. This is the first approach I tried. It was complex because I had to essentially make the GC accept both `Trace` and `DynTrace`. They often needed to be treated separately and there was unessicarry code duplication :(

Maybe we should make the `Trace` trait object safe by default, but keep `GcSafe` sized?
The main type that requires `GcSafe` is `Gc<'gc, T>` (for safety). That requirement could certainly be relaxed to only the constructors.......

Could we have separate traits `GcSafe` and `GcStaticType`? Any sized type must implement `GcStaticType` and give us the flags (NEEDS_TRACE/NEEDS_DROP) that we want.