### PR TITLE
Use procedural macros to implement `manually_traced` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 # gives zerogc 'batteries included' support.
 indexmap = { version = "1.6", optional = true }
 # Used for macros
-zerogc-derive = { version = "0.2.0-alpha.1" }
+zerogc-derive = { path = "libs/derive", version = "0.2.0-alpha.1" }
 
 [workspace]
 members = ["libs/simple", "libs/derive", "libs/context"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ readme = "README.md"
 # Providing support for these important libraries,
 # gives zerogc 'batteries included' support.
 indexmap = { version = "1.6", optional = true }
+# Used for macros
+zerogc-derive = { version = "0.2.0-alpha.1" }
 
 [workspace]
 members = ["libs/simple", "libs/derive", "libs/context"]

--- a/libs/derive/Cargo.toml
+++ b/libs/derive/Cargo.toml
@@ -16,6 +16,6 @@ zerogc = { version = "0.2.0-alpha.1", path = "../.." }
 
 [dependencies]
 # Proc macros
-syn = "1.0.55"
+syn = { version = "1.0.55", features = ["full", "extra-traits"] }
 quote = "1.0.8"
 proc-macro2 = "1"

--- a/libs/derive/src/lib.rs
+++ b/libs/derive/src/lib.rs
@@ -12,6 +12,8 @@ use std::collections::HashSet;
 use std::fmt::Display;
 use std::io::Write;
 
+mod macros;
+
 struct MutableFieldOpts {
     public: bool
 }
@@ -333,6 +335,22 @@ impl Parse for TypeAttrs {
         Ok(result)
     }
 }
+
+#[proc_macro]
+pub fn unsafe_gc_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let cloned_impl = input.clone();
+    let parsed = parse_macro_input!(input as macros::MacroInput);
+    let res = parsed.expand_output()
+        .unwrap_or_else(|e| e.to_compile_error());
+    debug_derive(
+        "unsafe_gc_impl!",
+        &"",
+        &format_args!("#[unsafe_gc_impl {{ {} }}", cloned_impl),
+        &res
+    );
+    res.into()
+}
+
 
 #[proc_macro_derive(Trace, attributes(zerogc))]
 pub fn derive_trace(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/libs/derive/src/lib.rs
+++ b/libs/derive/src/lib.rs
@@ -15,6 +15,24 @@ use std::io::Write;
 
 mod macros;
 
+/// Magic const that expands to either `::zerogc` or `crate::`
+/// depending on whether we are currently bootstraping (compiling `zerogc` itself)
+///
+/// This is equivalant to `$crate` for regular macros
+pub(crate) fn zerogc_crate() -> TokenStream {
+    if is_bootstraping() {
+        quote!(crate)
+    } else {
+        quote!(::zerogc)
+    }
+}
+
+/// If we are currently compiling the base crate `zerogc` itself
+pub(crate) fn is_bootstraping() -> bool {
+    ::proc_macro::tracked_env::var("CARGO_CRATE_NAME")
+        .expect("Expected `CARGO_CRATE_NAME`") == "zerogc"
+}
+
 struct MutableFieldOpts {
     public: bool
 }
@@ -410,6 +428,7 @@ fn impl_derive_trace(input: &DeriveInput) -> Result<TokenStream, syn::Error> {
 }
 
 fn trace_fields(fields: &Fields, access_ref: &mut dyn FnMut(Member) -> TokenStream) -> TokenStream {
+    let zerogc_crate = zerogc_crate();
     // TODO: Detect if we're a unit struct and implement `NullTrace`
     let mut result = Vec::new();
     for (index, field) in fields.iter().enumerate() {
@@ -417,7 +436,7 @@ fn trace_fields(fields: &Fields, access_ref: &mut dyn FnMut(Member) -> TokenStre
             Some(ref ident) => Member::Named(ident.clone()),
             None => Member::Unnamed(Index::from(index))
         });
-        result.push(quote!(::zerogc::Trace::visit(#val, &mut *visitor)?));
+        result.push(quote!(#zerogc_crate::Trace::visit(#val, &mut *visitor)?));
     }
     quote!(#(#result;)*)
 }
@@ -426,6 +445,7 @@ fn trace_fields(fields: &Fields, access_ref: &mut dyn FnMut(Member) -> TokenStre
 ///
 /// 1. Implement setters for `GcCell` fields using a write barrier
 fn impl_extras(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let mut extra_items = Vec::new();
     let gc_lifetime = info.config.gc_lifetime();
@@ -482,13 +502,13 @@ fn impl_extras(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, E
                         ))
                     };
                     // NOTE: Specially quoted since we want to blame the field for errors
-                    let field_as_ptr = quote_spanned!(field.span() => GcCell::as_ptr(&(*self.value()).#original_name));
-                    let barrier = quote_spanned!(field.span() => ::zerogc::GcDirectBarrier::write_barrier(&value, &self, offset));
+                    let field_as_ptr = quote_spanned!(field.span() => #zerogc_crate::cell::GcCell::as_ptr(&(*self.value()).#original_name));
+                    let barrier = quote_spanned!(field.span() => #zerogc_crate::GcDirectBarrier::write_barrier(&value, &self, offset));
                     extra_items.push(quote! {
                         #[inline] // TODO: Implement `GcDirectBarrier` ourselves
-                        #mutator_vis fn #mutator_name<Id>(self: ::zerogc::Gc<#gc_lifetime, Self, Id>, value: #value_ref_type)
-                            where Id: ::zerogc::CollectorId,
-                                   #value_ref_type: ::zerogc::GcDirectBarrier<#gc_lifetime, ::zerogc::Gc<#gc_lifetime, Self, Id>> {
+                        #mutator_vis fn #mutator_name<Id>(self: #zerogc_crate::Gc<#gc_lifetime, Self, Id>, value: #value_ref_type)
+                            where Id: #zerogc_crate::CollectorId,
+                                   #value_ref_type: #zerogc_crate::GcDirectBarrier<#gc_lifetime, #zerogc_crate::Gc<#gc_lifetime, Self, Id>> {
                             unsafe {
                                 let target_ptr = #field_as_ptr;
                                 let offset = target_ptr as usize - self.as_raw_ptr() as usize;
@@ -535,13 +555,14 @@ fn impl_extras(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, E
 
 
 fn impl_erase_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let mut generics: Generics = target.generics.clone();
     for param in &mut generics.params {
         match param {
             GenericParam::Type(ref mut type_param) => {
                 // Require all params are NullTrace
-                type_param.bounds.push(parse_quote!(::zerogc::NullTrace));
+                type_param.bounds.push(parse_quote!(#zerogc_crate::NullTrace));
             },
             GenericParam::Lifetime(ref mut l) => {
                 if l.lifetime == info.config.gc_lifetime() {
@@ -568,7 +589,7 @@ fn impl_erase_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream
     let collector_id = match info.config.collector_id {
         Some(ref id) => id.clone(),
         None => {
-            impl_generics.params.push(GenericParam::Type(parse_quote!(Id: ::zerogc::CollectorId)));
+            impl_generics.params.push(GenericParam::Type(parse_quote!(Id: #zerogc_crate::CollectorId)));
             parse_quote!(Id)
         }
     };
@@ -576,13 +597,13 @@ fn impl_erase_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream
     impl_generics.make_where_clause().predicates.push(WherePredicate::Type(PredicateType {
         lifetimes: None,
         bounded_ty: parse_quote!(Self),
-        bounds: parse_quote!(::zerogc::NullTrace),
+        bounds: parse_quote!(#zerogc_crate::NullTrace),
         colon_token: Default::default()
     }));
     let (_, ty_generics, _) = generics.split_for_impl();
     let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
     Ok(quote! {
-        unsafe impl #impl_generics ::zerogc::GcErase<'min, #collector_id>
+        unsafe impl #impl_generics #zerogc_crate::GcErase<'min, #collector_id>
             for #name #ty_generics #where_clause {
             // We can pass-through because we are NullTrace
             type Erased = Self;
@@ -590,6 +611,7 @@ fn impl_erase_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream
     })
 }
 fn impl_erase(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let mut generics: Generics = target.generics.clone();
     let mut rewritten_params = Vec::new();
@@ -603,10 +625,10 @@ fn impl_erase(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Er
         match param {
             GenericParam::Type(ref mut type_param) => {
                 let original_bounds = type_param.bounds.iter().cloned().collect::<Vec<_>>();
-                type_param.bounds.push(parse_quote!(::zerogc::GcErase<'min, #collector_id>));
+                type_param.bounds.push(parse_quote!(#zerogc_crate::GcErase<'min, #collector_id>));
                 type_param.bounds.push(parse_quote!('min));
                 let param_name = &type_param.ident;
-                let rewritten_type: Type = parse_quote!(<#param_name as ::zerogc::GcErase<'min, #collector_id>>::Erased);
+                let rewritten_type: Type = parse_quote!(<#param_name as #zerogc_crate::GcErase<'min, #collector_id>>::Erased);
                 rewritten_restrictions.push(WherePredicate::Type(PredicateType {
                     lifetimes: None,
                     bounded_ty: rewritten_type.clone(),
@@ -654,17 +676,17 @@ fn impl_erase(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Er
     let mut impl_generics = generics.clone();
     impl_generics.params.push(GenericParam::Lifetime(parse_quote!('min)));
     if info.config.collector_id.is_none() {
-        impl_generics.params.push(GenericParam::Type(parse_quote!(Id: ::zerogc::CollectorId)));
+        impl_generics.params.push(GenericParam::Type(parse_quote!(Id: #zerogc_crate::CollectorId)));
     }
     impl_generics.make_where_clause().predicates.extend(rewritten_restrictions);
     let (_, ty_generics, _) = generics.split_for_impl();
     let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
     let assert_erase = field_types.iter().map(|field_type| {
         let span = field_type.span();
-        quote_spanned!(span => <#field_type as ::zerogc::GcErase<'min, #collector_id>>::assert_erase();)
+        quote_spanned!(span => <#field_type as #zerogc_crate::GcErase<'min, #collector_id>>::assert_erase();)
     }).collect::<Vec<_>>();
     Ok(quote! {
-        unsafe impl #impl_generics ::zerogc::GcErase<'min, #collector_id>
+        unsafe impl #impl_generics #zerogc_crate::GcErase<'min, #collector_id>
             for #name #ty_generics #where_clause {
             type Erased = #name::<#(#rewritten_params),*>;
 
@@ -677,13 +699,14 @@ fn impl_erase(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Er
 
 
 fn impl_rebrand_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let mut generics: Generics = target.generics.clone();
     for param in &mut generics.params {
         match param {
             GenericParam::Type(ref mut type_param) => {
                 // Require all params are NullTrace
-                type_param.bounds.push(parse_quote!(::zerogc::NullTrace));
+                type_param.bounds.push(parse_quote!(#zerogc_crate::NullTrace));
             },
             GenericParam::Lifetime(ref mut l) => {
                 if l.lifetime == info.config.gc_lifetime() {
@@ -710,7 +733,7 @@ fn impl_rebrand_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStre
     let collector_id = match info.config.collector_id {
         Some(ref id) => id.clone(),
         None => {
-            impl_generics.params.push(GenericParam::Type(parse_quote!(Id: ::zerogc::CollectorId)));
+            impl_generics.params.push(GenericParam::Type(parse_quote!(Id: #zerogc_crate::CollectorId)));
             parse_quote!(Id)
         }
     };
@@ -718,13 +741,13 @@ fn impl_rebrand_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStre
     impl_generics.make_where_clause().predicates.push(WherePredicate::Type(PredicateType {
         lifetimes: None,
         bounded_ty: parse_quote!(Self),
-        bounds: parse_quote!(::zerogc::NullTrace),
+        bounds: parse_quote!(#zerogc_crate::NullTrace),
         colon_token: Default::default()
     }));
     let (_, ty_generics, _) = generics.split_for_impl();
     let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
     Ok(quote! {
-        unsafe impl #impl_generics ::zerogc::GcRebrand<'new_gc, #collector_id>
+        unsafe impl #impl_generics #zerogc_crate::GcRebrand<'new_gc, #collector_id>
             for #name #ty_generics #where_clause {
             // We can pass-through because we are NullTrace
             type Branded = Self;
@@ -732,6 +755,7 @@ fn impl_rebrand_nop(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStre
     })
 }
 fn impl_rebrand(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let mut generics: Generics = target.generics.clone();
     let mut rewritten_params = Vec::new();
@@ -745,9 +769,9 @@ fn impl_rebrand(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, 
         match param {
             GenericParam::Type(ref mut type_param) => {
                 let original_bounds = type_param.bounds.iter().cloned().collect::<Vec<_>>();
-                type_param.bounds.push(parse_quote!(::zerogc::GcRebrand<'new_gc, #collector_id>));
+                type_param.bounds.push(parse_quote!(#zerogc_crate::GcRebrand<'new_gc, #collector_id>));
                 let param_name = &type_param.ident;
-                let rewritten_type: Type = parse_quote!(<#param_name as ::zerogc::GcRebrand<'new_gc, #collector_id>>::Branded);
+                let rewritten_type: Type = parse_quote!(<#param_name as #zerogc_crate::GcRebrand<'new_gc, #collector_id>>::Branded);
                 rewritten_restrictions.push(WherePredicate::Type(PredicateType {
                     lifetimes: None,
                     bounded_ty: rewritten_type.clone(),
@@ -795,17 +819,17 @@ fn impl_rebrand(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, 
     let mut impl_generics = generics.clone();
     impl_generics.params.push(GenericParam::Lifetime(parse_quote!('new_gc)));
     if info.config.collector_id.is_none() {
-        impl_generics.params.push(GenericParam::Type(parse_quote!(Id: ::zerogc::CollectorId)));
+        impl_generics.params.push(GenericParam::Type(parse_quote!(Id: #zerogc_crate::CollectorId)));
     }
     let assert_rebrand = field_types.iter().map(|field_type| {
         let span = field_type.span();
-        quote_spanned!(span => <#field_type as ::zerogc::GcRebrand<'new_gc, #collector_id>>::assert_rebrand();)
+        quote_spanned!(span => <#field_type as #zerogc_crate::GcRebrand<'new_gc, #collector_id>>::assert_rebrand();)
     }).collect::<Vec<_>>();
     impl_generics.make_where_clause().predicates.extend(rewritten_restrictions);
     let (_, ty_generics, _) = generics.split_for_impl();
     let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
     Ok(quote! {
-        unsafe impl #impl_generics ::zerogc::GcRebrand<'new_gc, #collector_id>
+        unsafe impl #impl_generics #zerogc_crate::GcRebrand<'new_gc, #collector_id>
             for #name #ty_generics #where_clause {
             type Branded = #name::<#(#rewritten_params),*>;
 
@@ -816,6 +840,7 @@ fn impl_rebrand(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, 
     })
 }
 fn impl_trace(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let generics = add_trait_bounds_except(
         &target.generics, parse_quote!(zerogc::Trace),
@@ -884,15 +909,15 @@ fn impl_trace(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Er
         },
     }
     Ok(quote! {
-        unsafe impl #impl_generics ::zerogc::Trace for #name #ty_generics #where_clause {
-            const NEEDS_TRACE: bool = false #(|| <#field_types as ::zerogc::Trace>::NEEDS_TRACE)*;
+        unsafe impl #impl_generics #zerogc_crate::Trace for #name #ty_generics #where_clause {
+            const NEEDS_TRACE: bool = false #(|| <#field_types as #zerogc_crate::Trace>::NEEDS_TRACE)*;
 
             /*
              * The inline annotation adds this function's MIR to the metadata.
              * Without it cross-crate inlining is impossible (without LTO).
              */
             #[inline]
-            fn visit<V: ::zerogc::GcVisitor>(&mut self, #[allow(unused)] visitor: &mut V) -> Result<(), V::Err> {
+            fn visit<Visitor: #zerogc_crate::GcVisitor + ?Sized>(&mut self, #[allow(unused)] visitor: &mut Visitor) -> Result<(), Visitor::Err> {
                 #trace_impl
                 Ok(())
             }
@@ -900,10 +925,11 @@ fn impl_trace(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Er
     })
 }
 fn impl_gc_safe(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let collector_id = &info.config.collector_id;
     let generics = add_trait_bounds_except(
-        &target.generics, parse_quote!(zerogc::GcSafe),
+        &target.generics, parse_quote!(#zerogc_crate::GcSafe),
         &info.config.ignore_params,
         Some(&mut |other: &Ident| {
             if let Some(ref collector_id) = *collector_id {
@@ -936,7 +962,7 @@ fn impl_gc_safe(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, 
         quote!(false)
     } else {
         // We need to be dropped if any of our fields need to be dropped
-        quote!(false #(|| <#field_types as ::zerogc::GcSafe>::NEEDS_DROP)*)
+        quote!(false #(|| <#field_types as #zerogc_crate::GcSafe>::NEEDS_DROP)*)
     };
     let fake_drop_impl = if info.config.is_copy {
         /*
@@ -959,12 +985,12 @@ fn impl_gc_safe(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, 
         })
     };
     let verify_gc_safe = if info.config.is_copy {
-        quote!(::zerogc::assert_copy::<Self>())
+        quote!(#zerogc_crate::assert_copy::<Self>())
     } else {
-        quote!(#(<#field_types as GcSafe>::assert_gc_safe();)*)
+        quote!(#(<#field_types as #zerogc_crate::GcSafe>::assert_gc_safe();)*)
     };
     Ok(quote! {
-        unsafe impl #impl_generics ::zerogc::GcSafe
+        unsafe impl #impl_generics #zerogc_crate::GcSafe
             for #name #ty_generics #where_clause {
             const NEEDS_DROP: bool = #does_need_drop;
 
@@ -978,9 +1004,10 @@ fn impl_gc_safe(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, 
 
 
 fn impl_nop_trace(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream, Error> {
+    let zerogc_crate = zerogc_crate();
     let name = &target.ident;
     let generics = add_trait_bounds_except(
-        &target.generics, parse_quote!(zerogc::Trace),
+        &target.generics, parse_quote!(#zerogc_crate::Trace),
         &info.config.ignore_params, None
     )?;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
@@ -1007,30 +1034,30 @@ fn impl_nop_trace(target: &DeriveInput, info: &GcTypeInfo) -> Result<TokenStream
             let ty_span = t.span();
             quote_spanned! { ty_span =>
                 assert!(
-                    !<#t as Trace>::NEEDS_TRACE,
+                    !<#t as #zerogc_crate::Trace>::NEEDS_TRACE,
                     "Can't #[derive(NullTrace) with {}",
                     stringify!(#t)
                 );
             }
         }).collect::<Vec<_>>();
     Ok(quote! {
-        unsafe impl #impl_generics ::zerogc::Trace for #name #ty_generics #where_clause {
+        unsafe impl #impl_generics #zerogc_crate::Trace for #name #ty_generics #where_clause {
             const NEEDS_TRACE: bool = false;
 
             #[inline] // Should be const-folded away
-            fn visit<V: ::zerogc::GcVisitor>(&mut self, #[allow(unused)] visitor: &mut V) -> Result<(), V::Err> {
+            fn visit<Visitor: #zerogc_crate::GcVisitor + ?Sized>(&mut self, #[allow(unused)] visitor: &mut Visitor) -> Result<(), Visitor::Err> {
                 #(#trace_assertions)*
                 Ok(())
             }
         }
-        unsafe impl #impl_generics ::zerogc::TraceImmutable for #name #ty_generics #where_clause {
+        unsafe impl #impl_generics #zerogc_crate::TraceImmutable for #name #ty_generics #where_clause {
             #[inline] // Should be const-folded away
-            fn visit_immutable<V: ::zerogc::GcVisitor>(&self, #[allow(unused)] visitor: &mut V) -> Result<(), V::Err> {
+            fn visit_immutable<Visitor: #zerogc_crate::GcVisitor + ?Sized>(&self, #[allow(unused)] visitor: &mut Visitor) -> Result<(), Visitor::Err> {
                 #(#trace_assertions)*
                 Ok(())
             }
         }
-        unsafe impl #impl_generics ::zerogc::NullTrace for #name #ty_generics #where_clause {}
+        unsafe impl #impl_generics #zerogc_crate::NullTrace for #name #ty_generics #where_clause {}
     })
 }
 

--- a/libs/derive/src/macros.rs
+++ b/libs/derive/src/macros.rs
@@ -1,0 +1,757 @@
+//! Procedural macros for implementing `GcType`
+
+/*
+ * The main macro here is `unsafe_impl_gc`
+ */
+
+use proc_macro2::{Ident, TokenStream, TokenTree};
+use syn::{
+    GenericParam, WhereClause, Type, Expr, Error, Token, braced, bracketed,
+    ExprClosure, Generics, TypeParamBound, WherePredicate, PredicateType,
+    parse_quote
+};
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+
+use quote::{quote, quote_spanned};
+
+struct GenericParamInput(Vec<GenericParam>);
+impl Parse for GenericParamInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let inner;
+        bracketed!(inner in input);
+        let res = inner
+            .parse_terminated::<_, Token![,]>(GenericParam::parse)?;
+        Ok(GenericParamInput(res.into_iter().collect()))
+    }
+}
+
+fn empty_clause() -> WhereClause {
+    WhereClause {
+        predicates: Default::default(),
+        where_token: Default::default()
+    }
+}
+
+pub struct MacroInput {
+    /// The target type we are implementing
+    ///
+    /// This has unconstrained use of the parameters defined in `params`
+    target_type: Type,
+    /// The generic parameters (both types and lifetimes) that we want to
+    /// declare for each implementation
+    ///
+    /// This must not conflict with our internal names ;)
+    params: Vec<GenericParam>,
+    /// Custom bounds provided for each
+    ///
+    /// All of these bounds are optional.
+    /// This option can be omitted,
+    /// giving the equivalent of `bounds = {}`
+    bounds: CustomBounds,
+    /// The standard arguments to the macro
+    options: StandardOptions,
+    visit: VisitImpl
+}
+impl MacroInput {
+    fn basic_generics(&self) -> Generics {
+        let mut generics = Generics::default();
+        generics.params.extend(self.params.iter().cloned());
+        generics
+    }
+    pub fn expand_output(&self) -> Result<TokenStream, Error> {
+        let target_type = &self.target_type;
+        let trace_impl = self.expand_trace_impl(true)
+            .expect("Trace impl required");
+        let trace_immutable_impl = self.expand_trace_impl(false)?
+            .unwrap_or_default();
+        let gcsafe_impl = self.expand_gcsafe_impl();
+        let null_trace_clause = match self.options.null_trace {
+            TraitRequirements::Always => Some(empty_clause()),
+            TraitRequirements::Where(ref clause) => Some(clause.clone()),
+            TraitRequirements::Never => None
+        };
+        let null_trace_impl = if let Some(null_trace_clause) = null_trace_clause {
+            let mut generics = self.basic_generics();
+            generics.make_where_clause().predicates.extend(null_trace_clause.predicates.clone());
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+            quote! {
+                unsafe impl #impl_generics NullTrace for #target_type #ty_generics
+                    #where_clause {}
+            }
+        } else {
+            quote!()
+        };
+        let rebrand_impl = self.expand_brand_impl(true);
+        let erase_impl = self.expand_brand_impl(false);
+        Ok(quote! {
+            #trace_impl
+            #trace_immutable_impl
+            #null_trace_impl
+            #gcsafe_impl
+            #rebrand_impl
+            #erase_impl
+        })
+    }
+    fn expand_trace_impl(&self, mutable: bool) -> Result<Option<TokenStream>, Error> {
+        let target_type = &self.target_type;
+        let mut generics = self.basic_generics();
+        let clause = if mutable {
+            self.bounds.trace_where_clause(&self.params)
+        } else {
+            match self.bounds.trace_immutable_clause(&self.params) {
+                Some(clause) => clause,
+                None => return Ok(None), // They are requesting that we dont implement
+            }
+        };
+        generics.make_where_clause().predicates
+            .extend(clause.predicates);
+        let visit_impl = self.visit.expand_impl(mutable)?;
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+        let trait_name = if mutable { quote!(Trace) } else { quote!(TraceImmutable) };
+        let visit_method_name = if mutable { quote!(visit) } else { quote!(visit_immutable) };
+        Ok(Some(quote! {
+            unsafe impl #impl_generics #trait_name for #target_type #ty_generics #where_clause {
+                #[inline] // TODO: Should this be unconditional?
+                fn #visit_method_name<V: GcVisitor + ?Sized>(&mut self, visitor: &mut V) -> Result<(), V::Err> {
+                    #visit_impl
+                }
+            }
+        }))
+    }
+    fn expand_gcsafe_impl(&self) -> Option<TokenStream> {
+        let target_type = &self.target_type;
+        let mut generics = self.basic_generics();
+        generics.make_where_clause().predicates
+            .extend(match self.bounds.gcsafe_clause(&self.params) {
+                Some(clause) => clause.predicates,
+                None => return None // They are requesting we dont implement
+            });
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+        Some(quote! {
+            unsafe impl #impl_generics GcSafe for #target_type #ty_generics #where_clause {}
+        })
+    }
+    fn expand_brand_impl(&self, rebrand: bool /* true => rebrand, false => erase */) -> Option<TokenStream> {
+        let requirements = if rebrand { self.bounds.rebrand.clone() } else { self.bounds.erase.clone() };
+        if let Some(TraitRequirements::Never) = requirements  {
+            // They are requesting that we dont implement
+            return None;
+        }
+        let target_type = &self.target_type;
+        let mut generics = self.basic_generics();
+        for param in &self.params {
+            match param {
+                GenericParam::Type(ref tp) => {
+                    let type_name = &tp.ident;
+                    generics.make_where_clause()
+                        .predicates.push(WherePredicate::Type(PredicateType {
+                        lifetimes: None,
+                        bounded_ty: if rebrand {
+                            parse_quote!(<#type_name as GcRebrand<'new_gc, Id>>::Branded)
+                        } else {
+                            parse_quote!(<#type_name as GcErase<'new_gc, Id>>::Erased)
+                        },
+                        colon_token: Default::default(),
+                        bounds: tp.bounds.clone()
+                    }))
+                }
+                _ => {}
+            }
+        }
+        generics.make_where_clause().predicates
+            .extend(create_clause_with_default(
+                &requirements, &self.params,
+                if rebrand {
+                    vec![parse_quote!(GcRebrand<'new_gc, Id>)]
+                } else {
+                    vec![parse_quote!(GcErase<'min, Id>)]
+                }
+            ).unwrap_or_else(empty_clause).predicates);
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+        Some(quote! {
+            unsafe impl #impl_generics GcSafe for #target_type #ty_generics #where_clause {}
+        })
+    }
+}
+
+macro_rules! __full_field_ty {
+    ($field_type:ty, opt) => (Option<$field_type>);
+    ($field_type:ty,) => ($field_type);
+}
+macro_rules! __unwrap_field_ty {
+    ($opt_name:literal, $span:expr, $val:ident, $field_ty:ty, opt) => ($val);
+    ($opt_name:literal, $span:expr, $val:ident, $field_ty:ty,) => (match $val {
+        Some(inner) => inner,
+        None => return Err(Error::new(
+            $span, concat!("Missing required option: ", $opt_name)
+        ))
+    });
+}
+
+macro_rules! parse_field_opts {
+    ($parser:ident, {
+        $($opt_name:literal [$field_type:ty] $($suffix:ident)? => $field_name:ident;)*
+    }) => (parse_field_opts!($parser, complete = true, {
+        $($opt_name [$field_type] $($suffix)? => $field_name;)*
+    }));
+    ($parser:ident, complete = $complete:literal, {
+        $($opt_name:literal [$field_type:ty] $($suffix:ident)? => $field_name:ident;)*
+    }) => {{
+        assert!($complete, "Incomplte is unsupported!"); // NOTE: How would we parse an unknown type?
+        struct ParsedFields {
+            $($field_name: __full_field_ty!($field_type, $($suffix)?)),*
+        }
+        $(let mut $field_name = Option::<$field_type>::None;)*
+        #[allow(unused)]
+        let start_span = $parser.span();
+        while !$parser.is_empty() {
+            let ident = $parser.parse::<Ident>()
+                .map_err(|e| Error::new(e.span(), "Expected an option name"))?;
+            let s = ident.to_string();
+            match &*s {
+                $($opt_name => {
+                    if $field_name.is_some() {
+                        return Err(Error::new(
+                            ident.span(),
+                            concat!("Duplicate values specified for option: ", $opt_name),
+                        ))
+                    }
+                    $parser.parse::<Token![=>]>()?;
+                    $field_name = Some($parser.parse::<$field_type>()?);
+                    if $parser.peek(Token![,]) {
+                        $parser.parse::<Token![,]>()?;
+                    }
+                },)*
+                _ => {
+                    return Err(Error::new(
+                        ident.span(),
+                        format!("Unknown option name: {}", ident)
+                    ))
+                }
+            }
+        }
+        ParsedFields {
+            $($field_name: __unwrap_field_ty!($opt_name, start_span, $field_name, $field_type, $($suffix)?)),*
+        }
+    }};
+}
+impl Parse for MacroInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let res = parse_field_opts!(input, {
+            "target" [Type] => target_type;
+            "params" [GenericParamInput] => params;
+            "bounds" [CustomBounds] opt => bounds;
+            // StandardOptions
+            "null_trace" [TraitRequirements] => null_trace;
+            "branded" [Type] opt => branded;
+            "erased" [Type] opt => erased;
+            "NEEDS_TRACE" [Expr] => needs_trace;
+            "NEEDS_DROP" [Expr] => needs_drop;
+            "visit" [VisitClosure] opt => visit_closure;
+            "trace_mut" [VisitClosure] opt => trace_mut_closure;
+            "trace_immutable" [VisitClosure] opt => trace_immutable_closure;
+        });
+        let bounds = res.bounds.unwrap_or_default();
+        if let Some(TraitRequirements::Never) = bounds.trace  {
+            return Err(Error::new(
+                res.target_type.span(), "Bounds on `Trace` can't be never"
+            ))
+        }
+        let visit_impl = if let Some(visit_closure) = res.visit_closure {
+            if let Some(closure) = res.trace_immutable_closure.as_ref()
+                .or(res.trace_mut_closure.as_ref()) {
+                return Err(Error::new(
+                    closure.0.span(),
+                    "Cannot specifiy specific closure (trace_mut/trace_immutable) in addition to `visit`"
+                ))
+            }
+            VisitImpl::Generic { generic_impl: visit_closure.0 }
+        } else {
+            let trace_closure = res.trace_mut_closure.ok_or_else(|| {
+                Error::new(
+                    input.span(),
+                    "Either a `visit` or a `trace_mut` impl is required for Trace types"
+                )
+            })?;
+            let trace_immut_closure = match bounds.trace_immutable {
+                Some(TraitRequirements::Never) => {
+                    if let Some(closure) = res.trace_immutable_closure {
+                        return Err(Error::new(
+                            closure.0.span(),
+                            "Specified a `trace_immutable` implementation even though TraceImmutable is never implemented"
+                        ))
+                    } else {
+                        None
+                    }
+                },
+                _ => {
+                    let target_span = res.target_type.span();
+                    // we maybe implement `TraceImmutable` some of the time
+                    Some(res.trace_immutable_closure.ok_or_else(|| {
+                        Error::new(
+                            target_span,
+                            "Requires a `trace_immutable` implementation"
+                        )
+                    })?)
+                }
+            };
+            VisitImpl::Specific { mutable: trace_closure.0, immutable: trace_immut_closure.map(|closure| closure.0) }
+        };
+        Ok(MacroInput {
+            target_type: res.target_type,
+            params: res.params.0,
+            bounds,
+            options: StandardOptions {
+                null_trace: res.null_trace,
+                branded: res.branded,
+                erased: res.erased,
+                needs_trace: res.needs_trace,
+                needs_drop: res.needs_drop
+            },
+            visit: visit_impl
+        })
+    }
+}
+
+pub struct VisitClosure(Expr);
+impl Parse for VisitClosure {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let closure = match input.parse::<Expr>()? {
+            Expr::Closure(closure) => closure,
+            e => return Err(Error::new(e.span(), "Expected a closure"))
+        };
+        let ExprClosure {
+            ref attrs,
+            ref asyncness,
+            ref movability,
+            ref capture,
+            or1_token: _,
+            ref inputs,
+            or2_token: _,
+            ref output,
+            ref body, ..
+        } = closure;
+        if !attrs.is_empty() {
+            return Err(Error::new(
+                closure.span(),
+                "Attributes are forbidden on visit closure"
+            ));
+        }
+        if asyncness.is_some() || movability.is_some() || capture.is_some() {
+            return Err(Error::new(
+                closure.span(),
+                "Modifiers are forbidden on visit closure"
+            ));
+        }
+        if let ::syn::ReturnType::Default = output {
+            return Err(Error::new(
+                output.span(),
+                "Explicit return types are forbidden on visit closures"
+            ))
+        }
+        if inputs.len() != 2 {
+            return Err(Error::new(
+                inputs.span(),
+                "Expected exactly two arguments to visit closure"
+            ))
+        }
+        fn check_input(pat: &::syn::Pat, expected_name: &str,) -> Result<(), Error> {
+            match pat {
+                ::syn::Pat::Ident(
+                    ::syn::PatIdent {
+                        ref attrs,
+                        ref by_ref,
+                        ref mutability,
+                        ref ident,
+                        ref subpat
+                    }
+                ) => {
+                    if ident != expected_name {
+                        return Err(Error::new(
+                            ident.span(), format!(
+                                "Expected argument `{}` for closure",
+                                expected_name
+                            )
+                        ))
+                    }
+                    if !attrs.is_empty() {
+                        return Err(Error::new(
+                            pat.span(),
+                            format!(
+                                "Attributes are forbidden on closure arg `{}`",
+                                expected_name
+                            )
+                        ))
+                    }
+                    if let Some(by) = by_ref {
+                        return Err(Error::new(
+                            by.span(),
+                            format!(
+                                "Explicit mutability is forbidden on closure arg `{}`",
+                                expected_name
+                            )
+                        ))
+                    }
+                    if let Some(mutability) = mutability {
+                        return Err(Error::new(
+                            mutability.span(),
+                            format!(
+                                "Explicit mutability is forbidden on closure arg `{}`",
+                                expected_name
+                            )
+                        ))
+                    }
+                    if let Some((_, subpat)) = subpat {
+                        return Err(Error::new(
+                            subpat.span(),
+                            format!(
+                                "Subpatterns are forbidden on closure arg `{}`",
+                                expected_name
+                            )
+                        ))
+                    }
+                    assert_eq!(ident, expected_name);
+                    return Ok(())
+                },
+                _ => {},
+            }
+            Err(Error::new(pat.span(), format!(
+                "Expected argument {} to closure",
+                expected_name
+            )))
+        }
+        check_input(&inputs[0], "self")?;
+        check_input(&inputs[1], "visitor")?;
+        Ok(VisitClosure((**body).clone()))
+    }
+}
+
+/// Extra bounds
+#[derive(Default)]
+pub struct CustomBounds {
+    /// Additional bounds on the `Trace` implementation
+    trace: Option<TraitRequirements>,
+    /// Additional bounds on the `TraceImmutable` implementation
+    ///
+    /// If unspecified, this will default to the same as those
+    /// specified for `Trace`
+    trace_immutable: Option<TraitRequirements>,
+    /// Additional bounds on the `GcSafe` implementation
+    ///
+    /// If unspecified, this will default to the same as those
+    /// specified for `Trace`
+    gcsafe: Option<TraitRequirements>,
+    /// The requirements to implement `GcRebrand`
+    rebrand: Option<TraitRequirements>,
+    /// The requirements to implement `GcErase`
+    erase: Option<TraitRequirements>,
+}
+impl CustomBounds {
+    fn trace_where_clause(&self, generic_params: &[GenericParam]) -> WhereClause {
+        create_clause_with_default(
+            &self.trace, generic_params,
+            vec![parse_quote!(Trace)]
+        ).unwrap_or_else(|| unreachable!("Trace must always be implemented"))
+    }
+    fn trace_immutable_clause(&self, generic_params: &[GenericParam]) -> Option<WhereClause> {
+        create_clause_with_default(
+            &self.trace_immutable, generic_params,
+            vec![parse_quote!(TraceImmutable)]
+        )
+    }
+    fn gcsafe_clause(&self, generic_params: &[GenericParam]) -> Option<WhereClause> {
+        create_clause_with_default(
+            &self.gcsafe, generic_params,
+            vec![parse_quote!(GcSafe)]
+        )
+    }
+    fn rebrand_clause(&self, generic_params: &[GenericParam]) -> Option<WhereClause> {
+        create_clause_with_default(
+            &self.rebrand, generic_params,
+            vec![parse_quote!(GcRebrand<'new_gc, Id>)]
+        )
+    }
+    fn erase_clause(&self, generic_params: &[GenericParam]) -> Option<WhereClause> {
+        create_clause_with_default(
+            &self.erase, generic_params,
+            vec![parse_quote!(GcErase<'min, Id>)]
+        )
+    }
+}
+fn create_clause_with_default(
+    target: &Option<TraitRequirements>, generic_params: &[GenericParam],
+    default_bounds: Vec<TypeParamBound>
+) -> Option<WhereClause> {
+    Some(match *target {
+        Some(TraitRequirements::Never) => return None, // do not implement
+        Some(TraitRequirements::Where(ref explicit)) => explicit.clone(),
+        Some(TraitRequirements::Always) => {
+            // Absolutely no conditions on implementation
+            empty_clause()
+        }
+        None => {
+            let mut where_clause = empty_clause();
+            // Infer bounds for all params
+            for param in generic_params {
+                if let GenericParam::Type(ref t) = param {
+                    let ident = &t.ident;
+                    where_clause.predicates.push(WherePredicate::Type(PredicateType {
+                        bounded_ty: parse_quote!(#ident),
+                        colon_token: Default::default(),
+                        bounds: default_bounds.iter().cloned().collect(),
+                        lifetimes: None
+                    }))
+                }
+            }
+            let type_idents = generic_params.iter()
+                .filter_map(|param| match param {
+                    GenericParam::Type(ref t) => {
+                        Some(t.ident.clone())
+                    },
+                    _ => None
+                }).collect::<Vec<_>>();
+            parse_quote!(where #(#type_idents: Trace)*)
+        }
+    })
+}
+impl Parse for CustomBounds {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let inner;
+        braced!(inner in input);
+        let res = parse_field_opts!(inner, {
+            "Trace" [TraitRequirements] opt => trace;
+            "TraceImmutable" [TraitRequirements] opt => trace_immutable;
+            "GcSafe" [TraitRequirements] opt => gcsafe;
+            "GcRebrand" [TraitRequirements] opt => rebrand;
+            "GcErase" [TraitRequirements] opt => erase;
+        });
+        Ok(CustomBounds {
+            trace: res.trace,
+            trace_immutable: res.trace_immutable,
+            gcsafe: res.gcsafe,
+            rebrand: res.rebrand,
+            erase: res.erase
+        })
+    }
+}
+
+/// The standard options for the macro
+///
+/// Options are required unless wrapped in an `Option`
+/// (or explicitly marked optional)
+pub struct StandardOptions {
+    /// Requirements on implementing the NullTrace
+    ///
+    /// This is unsafe, and completely unchecked.
+    null_trace: TraitRequirements,
+    /// The associated type implemented as `GcRebrand::Branded`
+    branded: Option<Type>,
+    /// The associated type implemented as `GcErase::Erased`
+    erased: Option<Type>,
+    /// A (constant) expression determining whether the array needs to be traced
+    needs_trace: Expr,
+    /// A (constant) expression determining whether the type should be dropped
+    needs_drop: Expr,
+}
+
+/// The visit implementation.
+///
+/// The target object is always accessible through `self`.
+/// Other variables depend on the implementation.
+pub enum VisitImpl {
+    /// A generic implementation, whose code is shared across
+    /// both mutable/immutable implementations.
+    ///
+    /// This requires auto-replacement of certain magic variables,
+    /// which vary depending on whether we're generating a mutable
+    /// or immutable visitor.
+    ///
+    /// There are two variables accessible to the implementation: `self` and `visitor`
+    ///
+    /// | Magic Variable | for Trace  | for TraceImmutable |
+    /// | -------------- | ---------- | ------------------ |
+    /// | #mutability    | `` (empty) | `mut`              |
+    /// | #as_ref        | `as_ref`   | `as_mut`           |
+    /// | #iter          | `iter`     | `iter_mut`         |
+    /// | #visit_func    | `visit`    | `visit_immutable`  |
+    /// | #b             | `&`        | `&mut`             |
+    /// | ## (escape)    | `#`        | `#`                |
+    ///
+    /// Example visitor for `Vec<T>`:
+    /// ````no_test
+    /// for item in self.#iter() {
+    ///     #visit(item);
+    /// }
+    /// Ok(())
+    /// ````
+    Generic {
+        generic_impl: Expr
+    },
+    /// Specialized implementations which are different for
+    /// both `Trace` and `TraceImmutable`
+    Specific {
+        mutable: Expr,
+        immutable: Option<Expr>
+    }
+}
+enum MagicVarType {
+    Mutability,
+    AsRef,
+    Iter,
+    VisitFunc,
+    B
+}
+impl MagicVarType {
+    fn parse_ident(ident: &Ident) -> Result<MagicVarType, Error> {
+        let s = ident.to_string();
+        Ok(match &*s {
+            "mutability" => MagicVarType::Mutability,
+            "as_ref" => MagicVarType::AsRef,
+            "iter" => MagicVarType::Iter,
+            "visit_func" => MagicVarType::VisitFunc,
+            "b" => MagicVarType::B,
+            _ => return Err(Error::new(ident.span(), "Invalid magic variable name"))
+        })
+    }
+}
+impl VisitImpl {
+    fn expand_impl(&self, mutable: bool) -> Result<Expr, Error> {
+        use quote::ToTokens;
+        match *self {
+            VisitImpl::Generic { ref generic_impl } => {
+                ::syn::parse2(replace_magic_tokens(generic_impl.to_token_stream(), &mut |ident| {
+                    let res = match MagicVarType::parse_ident(ident)? {
+                        MagicVarType::Mutability => {
+                            if mutable {
+                                quote!(mut)
+                            } else {
+                                quote!()
+                            }
+                        }
+                        MagicVarType::AsRef => {
+                            if mutable {
+                                quote!(as_mut)
+                            } else {
+                                quote!(as_ref)
+                            }
+                        }
+                        MagicVarType::Iter => {
+                            if mutable {
+                                quote!(iter_mut)
+                            } else {
+                                quote!(iter)
+                            }
+                        }
+                        MagicVarType::VisitFunc => {
+                            if mutable {
+                                quote!(visit)
+                            } else {
+                                quote!(visit_immutable)
+                            }
+                        }
+                        MagicVarType::B => {
+                            if mutable {
+                                quote!(&mut)
+                            } else {
+                                quote!()
+                            }
+                        }
+                    };
+                    let span = ident.span(); // Reuse the span of the *input*
+                    Ok(quote_spanned!(span => #res))
+                })?)
+            }
+            VisitImpl::Specific { mutable: ref mutable_impl, ref immutable } => {
+                Ok(if mutable {
+                    mutable_impl.clone()
+                } else {
+                    immutable.clone().unwrap()
+                })
+            }
+        }
+    }
+}
+fn replace_magic_tokens(input: TokenStream, func: &mut dyn FnMut(&Ident) -> Result<TokenStream, Error>) -> Result<TokenStream, Error> {
+    use quote::TokenStreamExt;
+    let mut res = TokenStream::new();
+    let mut iter = input.into_iter();
+    while let Some(item) = iter.next() {
+        match item {
+            TokenTree::Group(ref group) => {
+                let old_span = group.span();
+                let delim = group.delimiter();
+                let new_stream = replace_magic_tokens(group.stream(), &mut *func)?;
+                let mut new_group = ::proc_macro2::Group::new(delim, new_stream);
+                new_group.set_span(old_span); // The overall span must be preserved
+                res.append(TokenTree::Group(new_group))
+            }
+            TokenTree::Punct(ref p) if p.as_char() == '#' => {
+                match iter.next() {
+                    None => return Err(Error::new(
+                        p.span(), "Unexpected EOF after magic token `#`"
+                    )),
+                    Some(TokenTree::Punct(ref p2)) if p2.as_char() == '#' => {
+                        // Pass through p2
+                        res.append(TokenTree::Punct(p2.clone()));
+                    }
+                    Some(TokenTree::Ident(ref ident)) => {
+                        res.extend(func(ident)?);
+                    },
+                    Some(ref other) => {
+                        return Err(Error::new(
+                            p.span(), format!(
+                                "Invalid token after magic token `#`: {}",
+                                other
+                            )
+                        ))
+                    }
+                }
+            }
+            TokenTree::Punct(_) | TokenTree::Ident(_) | TokenTree::Literal(_)=> {
+                // pass through
+                res.append(item);
+            }
+        }
+    }
+    Ok(res)
+}
+
+/// The requirements to implement a trait
+///
+/// In addition to a where clause, you can specify `always` for unconditional
+/// implementation and `never` to forbid generated implementations
+#[derive(Clone)]
+pub enum TraitRequirements {
+    /// The trait should never be implemented
+    Never,
+    /// The trait should only be implemented if
+    /// the specified where clause is satisfied
+    Where(WhereClause),
+    /// The trait should always be implemented
+    Always
+}
+
+impl Parse for TraitRequirements {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(syn::Ident) {
+            let ident = input.parse::<Ident>()?;
+            if ident == "always" {
+                Ok(TraitRequirements::Always)
+            } else if ident == "never" {
+                Ok(TraitRequirements::Never)
+            } else {
+                return Err(Error::new(
+                    ident.span(),
+                    "Invalid identifier for `TraitRequirement`"
+                ))
+            }
+        } else if input.peek(syn::token::Brace) {
+            let inner;
+            braced!(inner in input);
+            Ok(TraitRequirements::Where(inner.parse::<WhereClause>()?))
+        } else {
+            return Err(input.error("Invalid `TraitRequirement`"))
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ use core::marker::PhantomData;
 use core::hash::{Hash, Hasher};
 use core::fmt::{self, Debug, Formatter};
 
+use zerogc_derive::unsafe_gc_impl;
+
 #[macro_use]
 mod manually_traced;
 pub mod cell;
@@ -767,26 +769,24 @@ impl<T> DerefMut for AssumeNotTraced<T> {
         &mut self.0
     }
 }
-
-unsafe impl<T> Trace for AssumeNotTraced<T> {
-    const NEEDS_TRACE: bool = false;
-    #[inline(always)] // This method does nothing and is always a win to inline
-    fn visit<V: GcVisitor>(&mut self, _visitor: &mut V) -> Result<(), V::Err> {
-        Ok(())
-    }
+unsafe_gc_impl! {
+    target => AssumeNotTraced<T>,
+    params => [T],
+    bounds => {
+        // Unconditionally implement all traits
+        Trace => always,
+        TraceImmutable => always,
+        GcSafe => always,
+        GcRebrand => { where T: 'new_gc },
+        GcErase => { where T: 'min }
+    },
+    null_trace => always,
+    branded_type => AssumeNotTraced<T>,
+    erased_type => AssumeNotTraced<T>,
+    NEEDS_TRACE => false,
+    NEEDS_DROP => core::mem::needs_drop::<T>(),
+    visit => |self, visitor| { /* nop */ Ok(()) }
 }
-unsafe impl<T> TraceImmutable for AssumeNotTraced<T> {
-    #[inline(always)]
-    fn visit_immutable<V: GcVisitor>(&self, _visitor: &mut V) -> Result<(), V::Err> {
-        Ok(())
-    }
-}
-unsafe impl<T> NullTrace for AssumeNotTraced<T> {}
-/// No tracing implies GcSafe
-unsafe impl<T> GcSafe for AssumeNotTraced<T> {
-    const NEEDS_DROP: bool = core::mem::needs_drop::<T>();
-}
-unsafe_gc_brand!(AssumeNotTraced, T);
 
 /// Changes all references to garbage collected
 /// objects to match a specific lifetime.

--- a/src/manually_traced/core.rs
+++ b/src/manually_traced/core.rs
@@ -13,6 +13,7 @@ use zerogc_derive::unsafe_gc_impl;
 
 macro_rules! trace_tuple {
     { $single_param:ident } => {
+        trace_tuple_impl!();
         trace_tuple_impl!($single_param);
     };
     { $first_param:ident, $($param:ident),* } => {

--- a/src/manually_traced/core.rs
+++ b/src/manually_traced/core.rs
@@ -7,7 +7,7 @@
 use core::num::Wrapping;
 
 use crate::prelude::*;
-use crate::{GcDirectBarrier, CollectorId};
+use crate::GcDirectBarrier;
 
 use zerogc_derive::unsafe_gc_impl;
 

--- a/src/manually_traced/core.rs
+++ b/src/manually_traced/core.rs
@@ -285,7 +285,7 @@ unsafe_gc_impl! {
 
 #[cfg(test)]
 mod test {
-    use crate::dummy_impl::Gc;
+    use crate::dummy_impl::{DummyCollectorId, Gc};
     use zerogc_derive::Trace;
     use crate::prelude::*;
     #[test]
@@ -294,6 +294,7 @@ mod test {
         assert!(!<Option<(i32, char)> as Trace>::NEEDS_TRACE)
     }
     #[derive(Trace)]
+    #[zerogc(collector_id(DummyCollectorId))]
     struct Rec<'gc> {
         inner: Gc<'gc, Rec<'gc>>,
         inner_tuple: (Gc<'gc, Rec<'gc>>, Gc<'gc, Option<i32>>),

--- a/src/manually_traced/stdalloc.rs
+++ b/src/manually_traced/stdalloc.rs
@@ -30,17 +30,13 @@ unsafe_gc_impl! {
     NEEDS_TRACE => T::NEEDS_TRACE,
     NEEDS_DROP => true, // Internal memory
     visit => |self, visitor| {
-        visitor.#visit_func::<T>(#b **self);
+        visitor.#visit_func::<T>(#b **self)
     }
 }
 // We can only trace `Rc` and `Arc` if the inner type implements `TraceImmutable`
 unsafe_gc_impl! {
     target => Rc<T>,
-    params => [T],
-    bounds => {
-        Trace => { where T: TraceImmutable },
-        TraceImmutable => { where T: TraceImmutable }
-    },
+    params => [T: TraceImmutable],
     null_trace => { where T: NullTrace },
     NEEDS_TRACE => T::NEEDS_TRACE,
     NEEDS_DROP => true, // Internal memory
@@ -51,11 +47,7 @@ unsafe_gc_impl! {
 }
 unsafe_gc_impl! {
     target => Arc<T>,
-    params => [T],
-    bounds => {
-        Trace => { where T: TraceImmutable },
-        TraceImmutable => { where T: TraceImmutable }
-    },
+    params => [T: TraceImmutable],
     null_trace => { where T: NullTrace },
     NEEDS_TRACE => T::NEEDS_TRACE,
     NEEDS_DROP => true, // Internal memory

--- a/src/manually_traced/stdalloc.rs
+++ b/src/manually_traced/stdalloc.rs
@@ -12,6 +12,28 @@ use crate::prelude::*;
 
 // NOTE: Delegate to slice to avoid code duplication
 unsafe_trace_deref!(Vec, target = { [T] }; T);
+unsafe_impl_gc! {
+    target => Vec<T>,
+    params => [T],
+    null_trace => { where T: NullTrace },
+    NEEDS_TRACE => T::NEEDS_TRACE,
+    NEEDS_DROP => true, // Internal memory
+    visit => |$visit:expr, $target:ident| {
+        // Delegate to slice
+        visit(**$target as [T]);
+    }
+}
+unsafe_impl_gc! {
+    target => Box<T>,
+    params => [T],
+    null_trace => { where T: NullTrace },
+    NEEDS_TRACE => T::NEEDS_TRACE,
+    NEEDS_DROP => true, // Internal memory
+    visit => |$visit:expr, $target:ident| {
+        // Delegate to slice
+        visit(**$target);
+    }
+}
 unsafe_trace_deref!(Box, target = T);
 // We can only trace `Rc` and `Arc` if the inner type implements `TraceImmutable`
 unsafe_trace_deref!(Rc, T; immut = required; |rc| &**rc);

--- a/src/manually_traced/stdalloc.rs
+++ b/src/manually_traced/stdalloc.rs
@@ -10,33 +10,59 @@ use alloc::string::String;
 
 use crate::prelude::*;
 
-// NOTE: Delegate to slice to avoid code duplication
-unsafe_trace_deref!(Vec, target = { [T] }; T);
-unsafe_impl_gc! {
+use zerogc_derive::unsafe_gc_impl;
+
+unsafe_gc_impl! {
     target => Vec<T>,
     params => [T],
     null_trace => { where T: NullTrace },
     NEEDS_TRACE => T::NEEDS_TRACE,
     NEEDS_DROP => true, // Internal memory
-    visit => |$visit:expr, $target:ident| {
+    visit => |self, visitor| {
         // Delegate to slice
-        visit(**$target as [T]);
+        visitor.#visit_func::<[T]>(#b**self as #b [T])
     }
 }
-unsafe_impl_gc! {
+unsafe_gc_impl! {
     target => Box<T>,
     params => [T],
     null_trace => { where T: NullTrace },
     NEEDS_TRACE => T::NEEDS_TRACE,
     NEEDS_DROP => true, // Internal memory
-    visit => |$visit:expr, $target:ident| {
-        // Delegate to slice
-        visit(**$target);
+    visit => |self, visitor| {
+        visitor.#visit_func::<T>(#b **self);
     }
 }
-unsafe_trace_deref!(Box, target = T);
 // We can only trace `Rc` and `Arc` if the inner type implements `TraceImmutable`
-unsafe_trace_deref!(Rc, T; immut = required; |rc| &**rc);
-unsafe_trace_deref!(Arc, T; immut = required; |arc| &**arc);
+unsafe_gc_impl! {
+    target => Rc<T>,
+    params => [T],
+    bounds => {
+        Trace => { where T: TraceImmutable },
+        TraceImmutable => { where T: TraceImmutable }
+    },
+    null_trace => { where T: NullTrace },
+    NEEDS_TRACE => T::NEEDS_TRACE,
+    NEEDS_DROP => true, // Internal memory
+    visit => |self, visitor| {
+        // We must always visit immutable, since we have shared references
+        visitor.visit_immutable::<T>(&**self)
+    }
+}
+unsafe_gc_impl! {
+    target => Arc<T>,
+    params => [T],
+    bounds => {
+        Trace => { where T: TraceImmutable },
+        TraceImmutable => { where T: TraceImmutable }
+    },
+    null_trace => { where T: NullTrace },
+    NEEDS_TRACE => T::NEEDS_TRACE,
+    NEEDS_DROP => true, // Internal memory
+    visit => |self, visitor| {
+        // We must always visit immutable, since we have shared references
+        visitor.visit_immutable::<T>(&**self)
+    }
+}
 // String is a primitive with no internal references
 unsafe_trace_primitive!(String);

--- a/src/manually_traced/stdlib.rs
+++ b/src/manually_traced/stdlib.rs
@@ -3,11 +3,11 @@
 //! Types that are in `libcore` and are `#![no_std]` should go in the core module,
 //! but anything that requires the rest of the stdlib (including collections and allocations),
 //! should go in this module.
-use crate::prelude::*;
-
 use std::collections::{HashMap, HashSet};
 
 use zerogc_derive::unsafe_gc_impl;
+
+use crate::prelude::*;
 
 
 unsafe_gc_impl! {

--- a/src/manually_traced/stdlib.rs
+++ b/src/manually_traced/stdlib.rs
@@ -8,52 +8,35 @@ use crate::prelude::*;
 use std::collections::{HashMap, HashSet};
 use crate::CollectorId;
 
-unsafe_immutable_trace_iterable!(HashMap<K, V>; element = { (&K, &V) });
-unsafe impl<K: TraceImmutable, V: Trace> Trace for HashMap<K, V> {
-    const NEEDS_TRACE: bool = K::NEEDS_TRACE || V::NEEDS_TRACE;
+use zerogc_derive::unsafe_gc_impl;
 
-    fn visit<Visit: GcVisitor>(&mut self, visitor: &mut Visit) -> Result<(), Visit::Err> {
-        if !Self::NEEDS_TRACE { return Ok(()); };
-        for (key, value) in self.iter_mut() {
-            visitor.visit_immutable(key)?;
-            visitor.visit(value)?;
+
+unsafe_gc_impl! {
+    target => HashMap<K, V>,
+    params => [K: TraceImmutable, V],
+    null_trace => { where K: NullTrace, V: NullTrace },
+    NEEDS_TRACE => K::NEEDS_TRACE || V::NEEDS_TRACE,
+    NEEDS_DROP => true, // Internal memory
+    visit => |self, visitor| {
+        for (key, value) in self.#iter() {
+            visitor.visit_immutable::<K>(key)?;
+            visitor.#visit_func::<V>(value)?;
         }
         Ok(())
     }
 }
-unsafe impl<K: GcSafe + TraceImmutable, V: GcSafe> GcSafe for HashMap<K, V> {
-    const NEEDS_DROP: bool = true; // HashMap has internal memory
-}
-unsafe impl<'new_gc, Id, K, V> GcRebrand<'new_gc, Id> for HashMap<K, V>
-    where Id: CollectorId, K: TraceImmutable + GcRebrand<'new_gc, Id>,
-          V: GcRebrand<'new_gc, Id>,
-          <K as GcRebrand<'new_gc, Id>>::Branded: TraceImmutable + Sized,
-          <V as GcRebrand<'new_gc, Id>>::Branded: Sized {
-    type Branded = HashMap<
-        <K as GcRebrand<'new_gc, Id>>::Branded,
-        <V as GcRebrand<'new_gc, Id>>::Branded
-    >;
-}
-unsafe impl<'a, Id, K, V> GcErase<'a, Id> for HashMap<K, V>
-    where Id: CollectorId, K: TraceImmutable + GcErase<'a, Id>,
-          V: GcErase<'a, Id>,
-          <K as GcErase<'a, Id>>::Erased: TraceImmutable + Sized,
-          <V as GcErase<'a, Id>>::Erased: Sized {
-    type Erased = HashMap<
-        <K as GcErase<'a, Id>>::Erased,
-        <V as GcErase<'a, Id>>::Erased
-    >;
-}
-unsafe_immutable_trace_iterable!(HashSet<V>; element = { &V });
-unsafe impl<V: TraceImmutable> Trace for HashSet<V> {
-    const NEEDS_TRACE: bool = V::NEEDS_TRACE;
 
-    fn visit<Visit: GcVisitor>(&mut self, visitor: &mut Visit) -> Result<(), Visit::Err> {
-        if !Self::NEEDS_TRACE { return Ok(()); };
-        for value in self.iter() {
-            visitor.visit_immutable(value)?;
+
+unsafe_gc_impl! {
+    target => HashSet<T>,
+    params => [T: TraceImmutable],
+    null_trace => { where T: NullTrace },
+    NEEDS_TRACE => T::NEEDS_TRACE,
+    NEEDS_DROP => true, // Internal memory
+    visit => |self, visitor| {
+        for val in self.iter() {
+            visitor.visit_immutable::<T>(val)?;
         }
         Ok(())
     }
 }
-unsafe_gc_brand!(HashSet, immut = required; V);

--- a/src/manually_traced/stdlib.rs
+++ b/src/manually_traced/stdlib.rs
@@ -6,7 +6,6 @@
 use crate::prelude::*;
 
 use std::collections::{HashMap, HashSet};
-use crate::CollectorId;
 
 use zerogc_derive::unsafe_gc_impl;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,6 +23,8 @@ pub use crate::{
 };
 // Hack traits
 pub use crate::{GcBindHandle};
+// TODO: Should this trait be auto-imported???
+pub use crate::CollectorId;
 // Utils
 pub use crate::AssumeNotTraced;
 pub use crate::cell::GcCell;


### PR DESCRIPTION
Procedural macros are more flexible and will allow us to use a
single macro for all our manually traced code.
It should also help downstream crates start to utilize this.

I'm doing this cleanup first because It makes implementing #20 much easier