### PR TITLE
Use generic associated types for GcHandleSystem

### DIFF
--- a/libs/context/src/collector.rs
+++ b/libs/context/src/collector.rs
@@ -342,10 +342,10 @@ impl<C: RawCollectorImpl> WeakCollectorRef<C> {
 pub unsafe trait RawSimpleAlloc: RawCollectorImpl {
     fn alloc<'gc, T: GcSafe + 'gc>(context: &'gc CollectorContext<Self>, value: T) -> Gc<'gc, T, CollectorId<Self>>;
 }
-unsafe impl<'gc, T, C> GcSimpleAlloc<'gc, T> for CollectorContext<C>
-    where T: GcSafe + 'gc, C: RawSimpleAlloc {
+unsafe impl<C> GcSimpleAlloc for CollectorContext<C>
+    where C: RawSimpleAlloc {
     #[inline]
-    fn alloc(&'gc self, value: T) -> Gc<'gc, T, Self::Id> {
+    fn alloc<'gc, T>(&'gc self, value: T) -> Gc<'gc, T, Self::Id> where T: GcSafe + 'gc, {
         C::alloc(self, value)
     }
 }

--- a/libs/context/src/lib.rs
+++ b/libs/context/src/lib.rs
@@ -2,6 +2,7 @@
     negative_impls, // !Send is much cleaner than `PhantomData<Rc>`
     untagged_unions, // I want to avoid ManuallyDrop in unions
     const_fn_trait_bound, // So generics + const fn are unstable, huh?
+    generic_associated_types, // GcHandle
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 //! The implementation of (GcContext)[`::zerogc::GcContext`] that is

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,8 +21,6 @@ pub use crate::{
 pub use crate::{
     GcSafe, GcErase, GcRebrand, Trace, TraceImmutable, NullTrace
 };
-// Hack traits
-pub use crate::{GcBindHandle};
 // TODO: Should this trait be auto-imported???
 pub use crate::CollectorId;
 // Utils


### PR DESCRIPTION
Generic Associated Types significantly cleanup the `GcHandleSystem` interface, and are nessecarry for the tests to be generic over collectors.

Generic Associated Types have been accepted in [Rust RFC #1958](https://github.com/rust-lang/rfcs/blob/master/text/1598-generic_associated_types.md). However, much like specialization, they've been kind of in a semi-permenant unstable state for many years (the RFC is from *2016*).

I've tried to avoid tying the zerogc API to any nightly features, especially those that are unlikely to be stabalized soon.

However,t the implementations are already making heavy use of nightly, and it doesn't look like it's going away any time soon.

Although I still want to avoid using, in practice it seems silly to avoid using GAT when it cleans up the handle API so significantly.

Unfortunately there is a tiny issue with the implementation right now and there is an error with a where bound in `zerogc-context`. I hope to fix that eventually.