### PR TITLE
Make tests generic over any `GcSystem`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = { version = "1.6", optional = true }
 zerogc-derive = { path = "libs/derive", version = "0.2.0-alpha.3" }
 
 [workspace]
-members = ["libs/simple", "libs/derive", "libs/context"]
+members = ["libs/simple", "libs/derive", "libs/context", "libs/test"]
 
 [profile.dev]
 opt-level = 1

--- a/libs/context/src/collector.rs
+++ b/libs/context/src/collector.rs
@@ -342,10 +342,10 @@ impl<C: RawCollectorImpl> WeakCollectorRef<C> {
 pub unsafe trait RawSimpleAlloc: RawCollectorImpl {
     fn alloc<'gc, T: GcSafe + 'gc>(context: &'gc CollectorContext<Self>, value: T) -> Gc<'gc, T, CollectorId<Self>>;
 }
-unsafe impl<'gc, T, C> GcSimpleAlloc<'gc, T> for CollectorContext<C>
-    where T: GcSafe + 'gc, C: RawSimpleAlloc {
+unsafe impl<C> GcSimpleAlloc for CollectorContext<C>
+    where C: RawSimpleAlloc {
     #[inline]
-    fn alloc(&'gc self, value: T) -> Gc<'gc, T, Self::Id> {
+    fn alloc<'gc, T>(&'gc self, value: T) -> Gc<'gc, T, Self::Id> where T: GcSafe + 'gc, {
         C::alloc(self, value)
     }
 }

--- a/libs/context/src/lib.rs
+++ b/libs/context/src/lib.rs
@@ -2,6 +2,7 @@
     negative_impls, // !Send is much cleaner than `PhantomData<Rc>`
     untagged_unions, // I want to avoid ManuallyDrop in unions
     const_fn_trait_bound, // So generics + const fn are unstable, huh?
+    generic_associated_types, // GcHandle
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 //! The implementation of (GcContext)[`::zerogc::GcContext`] that is

--- a/libs/test/Cargo.toml
+++ b/libs/test/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "zerogc-test"
+description = "The custom test harness for zerogc collectors"
+version = "0.2.0-alpha.3"
+authors = ["Techcable <Techcable@techcable.net>"]
+repository = "https://github.com/DuckLogic/zerogc"
+readme = "../../README.md"
+license = "MIT"
+edition = "2018"
+# For internal use only
+publish = false
+
+[[bin]]
+name = "zerogc-test"
+main = "src/main.rs"
+
+[dependencies]
+zerogc = { path = "../..", version = "0.2.0-alpha.3" }
+zerogc-derive = { path = "../derive", version = "0.2.0-alpha.3"}
+# Concurrency
+parking_lot = "0.11"
+crossbeam-utils = "0.8"
+# Logging
+slog = "2.7"
+slog-term = "2.6"
+# Error handling
+anyhow = "1"
+# Used for binary_trees_parallel examle
+rayon = "1.3"
+# CLI
+clap = { version = "3.0.0-beta.2", optional = true }
+
+[dependencies.zerogc-simple]
+path = "../simple"
+version = "0.2.0-alpha.3"
+no-default-features = true
+optional = true
+
+[features]
+default = ["simple", "cli"]
+# Enable the simple collector,
+simple = ["zerogc-simple", "zerogc-simple/sync", "zerogc-simple/small-object-arenas"]
+# Enable multiple collectors (for the simple collector)
+simple-multiple = ["zerogc-simple/multiple-collectors"]
+# Enable features needed for the CLI
+cli = ["clap"]

--- a/libs/test/src/examples/binary_trees.rs
+++ b/libs/test/src/examples/binary_trees.rs
@@ -1,20 +1,18 @@
-#![feature(
-    arbitrary_self_types, // Unfortunately this is required for methods on Gc refs
-)]
 use zerogc::prelude::*;
-use zerogc_simple::{SimpleCollector, SimpleCollectorContext, Gc, CollectorId as SimpleCollectorId};
+use zerogc::{Gc, CollectorId};
 use zerogc_derive::Trace;
 
-use slog::{Logger, Drain, o};
+use slog::{Logger, Drain,};
+use crate::{GcTest, TestContext};
 
 #[derive(Trace)]
-#[zerogc(collector_id(SimpleCollectorId))]
-struct Tree<'gc> {
+#[zerogc(collector_id(Id))]
+struct Tree<'gc, Id: CollectorId> {
     #[zerogc(mutable(public))]
-    children: GcCell<Option<(Gc<'gc, Tree<'gc>>, Gc<'gc, Tree<'gc>>)>>,
+    children: GcCell<Option<(Gc<'gc, Tree<'gc, Id>, Id>, Gc<'gc, Tree<'gc, Id>, Id>)>>,
 }
 
-fn item_check(tree: &Tree) -> i32 {
+fn item_check<'gc, Id: CollectorId>(tree: &Tree<'gc, Id>) -> u32 {
     if let Some((left, right)) = tree.children.get() {
         1 + item_check(&right) + item_check(&left)
     } else {
@@ -22,8 +20,7 @@ fn item_check(tree: &Tree) -> i32 {
     }
 }
 
-fn bottom_up_tree<'gc>(collector: &'gc SimpleCollectorContext, depth: i32)
-                       -> Gc<'gc, Tree<'gc>> {
+fn bottom_up_tree<'gc, Ctx: TestContext>(collector: &'gc Ctx, depth: u32) -> Gc<'gc, Tree<'gc, Ctx::Id>, Ctx::Id> {
     let tree = collector.alloc(Tree { children: GcCell::new(None) });
     if depth > 0 {
         let right = bottom_up_tree(collector, depth - 1);
@@ -33,33 +30,29 @@ fn bottom_up_tree<'gc>(collector: &'gc SimpleCollectorContext, depth: i32)
     tree
 }
 
-fn inner(
-    gc: &mut SimpleCollectorContext,
-    depth: i32, iterations: u32
+fn inner<Ctx: TestContext>(
+    gc: &mut Ctx,
+    depth: u32, iterations: u32
 ) -> String {
-    let chk: i32 = (0 .. iterations).into_iter().map(|_| {
+    let chk: u32 = (0 .. iterations).into_iter().map(|_| {
         safepoint_recurse!(gc, |gc| {
-            let a = bottom_up_tree(&gc, depth);
+            let a = bottom_up_tree(&*gc, depth);
             item_check(&a)
         })
     }).sum();
     format!("{}\t trees of depth {}\t check: {}", iterations, depth, chk)
 }
 
-fn main() {
-    let n = std::env::args().nth(1)
-        .and_then(|n| n.parse().ok())
+pub const EXAMPLE_NAME: &str = file!();
+pub fn main<Ctx: GcTest>(logger: &Logger, gc: Ctx, args: &[&str]) -> anyhow::Result<()> {
+    let n = args.get(0)
+        .map(|arg| arg.parse::<u32>().unwrap())
         .unwrap_or(10);
+    assert!(n >= 0);
     let min_depth = 4;
     let max_depth = if min_depth + 2 > n { min_depth + 2 } else { n };
 
-    let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-    let logger = Logger::root(
-        slog_term::FullFormat::new(plain).build().fuse(),
-        o!("bench" => file!())
-    );
-    let collector = SimpleCollector::with_logger(logger);
-    let mut gc = collector.into_context();
+    let mut gc = gc.into_context();
     {
         let depth = max_depth + 1;
         let tree = bottom_up_tree(&gc, depth);
@@ -74,11 +67,12 @@ fn main() {
             let depth = half_depth * 2;
             let iterations = 1 << ((max_depth - depth + min_depth) as u32);
             let message = safepoint_recurse!(gc, |new_gc| {
-                inner(&mut new_gc, depth, iterations)
+                inner(&mut *new_gc, depth, iterations)
             });
             println!("{}", message);
         })
     });
 
     println!("long lived tree of depth {}\t check: {}", max_depth, item_check(&long_lived_tree));
+    Ok(())
 }

--- a/libs/test/src/examples/binary_trees_parallel.rs
+++ b/libs/test/src/examples/binary_trees_parallel.rs
@@ -2,20 +2,21 @@
     arbitrary_self_types, // Unfortunately this is required for methods on Gc refs
 )]
 use zerogc::prelude::*;
-use zerogc_simple::{SimpleCollector, SimpleCollectorContext, Gc, CollectorId as SimpleCollectorId};
 use zerogc_derive::Trace;
 
 use rayon::prelude::*;
-use slog::{Logger, Drain, o};
+use slog::{Logger, Drain};
+use crate::{GcTest, GcSyncTest, TestContext};
+use zerogc::GcHandleSystem;
 
 #[derive(Trace)]
-#[zerogc(collector_id(SimpleCollectorId))]
-struct Tree<'gc> {
+#[zerogc(collector_id(Id))]
+pub(crate) struct Tree<'gc, Id: CollectorId> {
     #[zerogc(mutable(public))]
-    children: GcCell<Option<(Gc<'gc, Tree<'gc>>, Gc<'gc, Tree<'gc>>)>>,
+    children: GcCell<Option<(Gc<'gc, Tree<'gc, Id>, Id>, Gc<'gc, Tree<'gc, Id>, Id>)>>,
 }
 
-fn item_check(tree: &Tree) -> i32 {
+fn item_check<Id: CollectorId>(tree: &Tree<Id>) -> i32 {
     if let Some((left, right)) = tree.children.get() {
         1 + item_check(&right) + item_check(&left)
     } else {
@@ -23,8 +24,7 @@ fn item_check(tree: &Tree) -> i32 {
     }
 }
 
-fn bottom_up_tree<'gc>(collector: &'gc SimpleCollectorContext, depth: i32)
-                       -> Gc<'gc, Tree<'gc>> {
+fn bottom_up_tree<'gc, Ctx: TestContext>(collector: &'gc Ctx, depth: i32) -> Gc<'gc, Tree<'gc, Ctx::Id>, Ctx::Id> {
     let tree = collector.alloc(Tree { children: GcCell::new(None) });
     if depth > 0 {
         let right = bottom_up_tree(collector, depth - 1);
@@ -34,33 +34,28 @@ fn bottom_up_tree<'gc>(collector: &'gc SimpleCollectorContext, depth: i32)
     tree
 }
 
-fn inner(
-    collector: &SimpleCollector,
+fn inner<GC: GcSyncTest>(
+    collector: &GC,
     depth: i32, iterations: u32
 ) -> String {
     let chk: i32 = (0 .. iterations).into_par_iter().map(|_| {
         let mut gc = collector.create_context();
         safepoint_recurse!(gc, |gc| {
-            let a = bottom_up_tree(&gc, depth);
+            let a = bottom_up_tree(&*gc, depth);
             item_check(&a)
         })
     }).sum();
     format!("{}\t trees of depth {}\t check: {}", iterations, depth, chk)
 }
 
-fn main() {
-    let n = std::env::args().nth(1)
+pub const EXAMPLE_NAME: &str = file!();
+pub fn main<GC: GcSyncTest>(logger: &Logger, collector: GC, args: &[&str]) -> anyhow::Result<()> {
+    let n = args.get(0)
         .and_then(|n| n.parse().ok())
         .unwrap_or(10);
     let min_depth = 4;
     let max_depth = if min_depth + 2 > n { min_depth + 2 } else { n };
 
-    let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
-    let logger = Logger::root(
-        slog_term::FullFormat::new(plain).build().fuse(),
-        o!("bench" => file!())
-    );
-    let collector = SimpleCollector::with_logger(logger);
     let mut gc = collector.create_context();
     {
         let depth = max_depth + 1;
@@ -70,7 +65,7 @@ fn main() {
     safepoint!(gc, ());
 
     let long_lived_tree = bottom_up_tree(&gc, max_depth);
-    let long_lived_tree = long_lived_tree.create_handle();
+    let long_lived_tree = GC::HandleSystem::<'_, '_, _>::create_handle(long_lived_tree);
     let frozen = freeze_context!(gc);
 
     (min_depth / 2..max_depth / 2 + 1).into_par_iter().for_each(|half_depth| {

--- a/libs/test/src/examples/mod.rs
+++ b/libs/test/src/examples/mod.rs
@@ -1,0 +1,71 @@
+use zerogc::{GcContext, Gc};
+use slog::Logger;
+use crate::{GcTest, GcSyncTest};
+use slog::Drain;
+
+mod binary_trees;
+pub(crate) mod binary_trees_parallel;
+
+
+macro_rules! define_example {
+    (def @kind sync fn $name:ident($args:ident) $body:expr) => {
+        fn $name<GC: GcSyncTest>($args: &[&str]) -> anyhow::Result<()> {
+            $body
+        }
+    };
+    (def @kind nosync fn $name:ident($args:ident) $body:expr) => {
+        fn $name<GC: GcTest>($args: &[&str]) -> anyhow::Result<()> {
+            $body
+        }
+    };
+    ($name:ident, $target_module:ident, $kind:ident) => {
+        define_example!(def @kind $kind fn $name(args) {
+            let plain = slog_term::PlainSyncDecorator::new(std::io::stdout());
+            let logger = Logger::root(
+                slog_term::FullFormat::new(plain).build().fuse(),
+                ::slog::o!("bench" => file!())
+            );
+            let collector = GC::create_collector(logger);
+            self::$target_module::main(&logger, collector, args)
+        });
+    };
+}
+define_example!(binary_trees, binary_trees, nosync);
+define_example!(binary_trees_parallel, binary_trees_parallel, sync);
+
+#[derive(Copy, Clone)]
+pub enum ExampleKind {
+    BinaryTrees,
+    BinaryTreesParallel
+}
+#[derive(Default)]
+pub struct ExampleArgs {
+    binary_trees_size: Option<u32>,
+}
+
+macro_rules! run_example {
+    ($name:ident, $gc:ident, $($arg:expr),*) => {{
+        eprintln!(concat!("Running ", stringify!($name), ":"));
+        let owned_args = vec![$(Option::map($arg, |item| item.to_string())),*];
+        while let Some(None) = owned_args.last() {
+            assert_eq!(owned_args.pop(), None);
+        }
+        let args = owned_args.iter().enumerate().map(|(index, opt)| opt.as_ref().unwrap_or_else(|| {
+            panic!("Arg #{} is None: {:?}", index, owned_args)
+        }).as_str()).collect::<Vec<_>>();
+        use anyhow::Context;
+        let () = ($name::<$gc>)(&*args).with_context(|| format!("Running example {:?}", stringify!($name)))?;
+    }};
+}
+/// Run all the example for the specified (non-Sync) collector
+pub fn run_examples_non_sync<GC: GcTest>(args: ExampleArgs) -> anyhow::Result<()> {
+    run_example!(binary_trees, GC, args.binary_trees_size);
+    Ok(())
+}
+/// Run the examples for the specified Sync collector,
+/// including all the non-sync examples;
+pub fn run_examples_sync<GC: GcSyncTest>(args: ExampleArgs) -> anyhow::Result<()> {
+    run_examples_non_sync::<GC>(args);
+    run_example!(binary_trees_parallel, GC, args.binary_trees_size);
+    Ok(())
+}

--- a/libs/test/src/lib.rs
+++ b/libs/test/src/lib.rs
@@ -1,0 +1,24 @@
+#![feature(
+    arbitrary_self_types, // Unfortunately this is required for methods on Gc refs
+    generic_associated_types, // We need more abstraction
+)]
+use zerogc::{
+    GcContext, GcSystem, GcSimpleAlloc, GcSafe, CollectorId, GcHandleSystem, GcErase,
+    GcRebrand, GcHandle, GcBindHandle
+};
+use slog::Logger;
+
+pub mod examples;
+
+pub trait TestContext: GcContext + GcSimpleAlloc {
+}
+
+pub trait GcTest: GcSystem + GcHandleSystem {
+    type Ctx: TestContext<Id=Self::Id>;
+    fn create_collector(logger: Logger) -> Self;
+    fn into_context(self) -> Self::Ctx;
+}
+pub trait GcSyncTest: Sync + GcTest {
+    fn create_context(&self) -> Self::Ctx;
+}
+

--- a/libs/test/src/main.rs
+++ b/libs/test/src/main.rs
@@ -1,0 +1,64 @@
+use clap::Clap;
+
+/// Tests garbage collectors
+#[derive(Clap, Debug)]
+#[clap(author, version)]
+pub struct GcTestOpts {
+    #[clap(arg_enum, default_value = "GcType::all()")]
+    #[clap(subcommand)]
+    subcommand: Subcommand
+}
+
+/// The type of garbage collector
+#[derive(Clap, Debug)]
+enum GcType {
+    Simple
+}
+impl GcType {
+    fn all() -> Vec<GcType> {
+        vec![GcType::Simple]
+    }
+    fn is_supported(&self) -> bool {
+        match *self {
+            GcType::Simple => cfg!(feature = "simple")
+        }
+    }
+    fn is_sync(&self) -> bool {
+        match *self {
+            GcType::Simple =>
+        }
+    }
+}
+
+#[derive(Clap)]
+pub enum Subcommand {
+    Example(ExampleOpts)
+}
+
+/// Run the examples
+#[derive(Clap)]
+pub struct ExampleOpts {
+    /// The size of the binary trees
+    #[clap(long)]
+    binary_trees_size: Option<u32>,
+    /// The list of examples to name,
+    /// defaults to all of them
+    #[clap(default_value = "ExampleKind::all()")]
+    #[clap(arg_enum)]
+    examples: Vec<ExampleKind>
+}
+#[derive(Clap, Debug, PartialEq)]
+pub enum ExampleKind {
+    BinaryTrees,
+    BinaryTreesParallel
+}
+impl ExampleKind {
+    fn all() -> Vec<ExampleKind>
+}
+
+fn main() -> anyhow::Result<()> {
+    let opts = GcTestOpts::parse();
+    match opts {
+
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,8 +21,6 @@ pub use crate::{
 pub use crate::{
     GcSafe, GcErase, GcRebrand, Trace, TraceImmutable, NullTrace
 };
-// Hack traits
-pub use crate::{GcBindHandle};
 // TODO: Should this trait be auto-imported???
 pub use crate::CollectorId;
 // Utils


### PR DESCRIPTION
This depends on #27 

While zerogc is implementation agnostic in theory, in practice, it would be difficult to test multiple implementations without copying all the tests.

Therefore, I've refactored the tests into a separate `zerogc-test` crate, that is able to test any `GcSystem`.